### PR TITLE
Add structured feature planning template for MediaSet project

### DIFF
--- a/.github/chatmodes/code-reviewer.chatmode.md
+++ b/.github/chatmodes/code-reviewer.chatmode.md
@@ -1,7 +1,11 @@
-# Code Reviewer Chat Mode
+---
+description: 'Review code changes for quality, style adherence, and best practices without making direct edits.'
+tools: ['codebase', 'changes', 'fetch', 'problems', 'search', 'searchResults', 'usages', 'githubRepo']
+---
 
-You are an experienced code reviewer for the MediaSet project. Your role is to review code changes and provide constructive feedback
-and adherence to [project standards](../copilot-instructions.md) without making direct code changes.
+# Code Reviewer
+
+You are an experienced code reviewer for the MediaSet project. Your role is to review code changes and provide constructive feedback on code quality and adherence to [project standards](../copilot-instructions.md) without making direct code changes.
 
 ## Review Guidelines
 
@@ -68,7 +72,7 @@ and adherence to [project standards](../copilot-instructions.md) without making 
 
 Structure your review comments as follows:
 
-```
+```markdown
 ## Overall Assessment
 Brief summary of the code change and its impact
 

--- a/.github/chatmodes/feature-planning.chatmode.md
+++ b/.github/chatmodes/feature-planning.chatmode.md
@@ -1,12 +1,13 @@
-# GitHub Copilot Chat Mode: Feature Planning
+---
+description: 'Create comprehensive implementation plans for new features with detailed technical specifications and step-by-step breakdown.'
+tools: ['codebase', 'search', 'searchResults', 'usages', 'fetch', 'githubRepo', 'problems', 'new']
+---
 
-This chat mode provides a structured approach for planning new features in the MediaSet project.
+# Feature Planning
 
-## Trigger
+This chat mode provides a structured approach for planning new features in the MediaSet project. When activated, it creates detailed implementation plans in the `ImplementationDetails/` folder.
 
-When a user asks to "plan out a feature" or requests a "feature plan", activate this mode.
-
-## Process
+## Planning Workflow
 
 ### 1. Create Planning Document
 
@@ -19,7 +20,7 @@ Create a new markdown file in the `ImplementationDetails/` folder at the project
 
 The planning document should follow this template structure:
 
-```markdown
+```
 # [Feature Name] Implementation Plan
 
 ## Overview
@@ -167,15 +168,6 @@ The planning document should follow this template structure:
 - Third-party API integrations
 - Infrastructure changes
 
-## Timeline Estimate
-
-- **Planning**: [X hours/days]
-- **Backend Implementation**: [X hours/days]
-- **Frontend Implementation**: [X hours/days]
-- **Testing**: [X hours/days]
-- **Documentation**: [X hours/days]
-- **Total**: [X hours/days]
-
 ## References
 
 - Related issues/tickets
@@ -226,7 +218,7 @@ When creating a feature plan:
 - **Risk Management**: Identifies potential issues early
 - **Scope Control**: Helps define clear boundaries for the feature
 
-## Note
+## When to Use
 
 This planning mode is especially useful for:
 - Complex features spanning multiple layers


### PR DESCRIPTION
This pull request updates the chat mode configuration files for code review and feature planning to improve clarity, structure, and metadata. The most important changes include adding front matter metadata, refining instructions and templates, and renaming the files for consistency.

**Chat mode metadata and file organization:**
* Added front matter metadata (`description`, `tools`) to both `.github/chatmodes/code-reviewer.chatmode.md` and `.github/chatmodes/feature-planning.chatmode.md` to define their purpose and available tools. [[1]](diffhunk://#diff-016141bf8922150969bc1804b43ecb5fd47d1821f7e016021898b461b8af7059L1-R8) [[2]](diffhunk://#diff-01c7d812b2af18a7a52fa0e9c97598c62b7ae089ed4222baa477513f485ea27eL1-R10)
* Renamed the files from `.md` to `.chatmode.md` for clearer identification and organization. [[1]](diffhunk://#diff-016141bf8922150969bc1804b43ecb5fd47d1821f7e016021898b461b8af7059L1-R8) [[2]](diffhunk://#diff-01c7d812b2af18a7a52fa0e9c97598c62b7ae089ed4222baa477513f485ea27eL1-R10)

**Instruction and template improvements:**
* Refined the code reviewer instructions to clarify the role and improved formatting by specifying markdown for review comments. [[1]](diffhunk://#diff-016141bf8922150969bc1804b43ecb5fd47d1821f7e016021898b461b8af7059L1-R8) [[2]](diffhunk://#diff-016141bf8922150969bc1804b43ecb5fd47d1821f7e016021898b461b8af7059L71-R75)
* Enhanced the feature planning workflow description, clarified when the mode should be activated, and improved the planning document template structure. [[1]](diffhunk://#diff-01c7d812b2af18a7a52fa0e9c97598c62b7ae089ed4222baa477513f485ea27eL1-R10) [[2]](diffhunk://#diff-01c7d812b2af18a7a52fa0e9c97598c62b7ae089ed4222baa477513f485ea27eL22-R23) [[3]](diffhunk://#diff-01c7d812b2af18a7a52fa0e9c97598c62b7ae089ed4222baa477513f485ea27eL229-R221)
* Removed the timeline estimate section from the feature planning template for a more streamlined process.