### PR TITLE
fix(ci): update release-please action and fix warnings [AI-assisted]

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,13 +13,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: google-github-actions/release-please-action@v4
+      - uses: googleapis/release-please-action@v4
         with:
-          # Use a single repo-level version for both API and UI
-          release-type: simple
-          # Start versioning at v0.1.0
-          bootstrap-sha: ${{ github.sha }}
-          # Package name for the release
-          package-name: mediaset
-          # Include both API and UI components in changelog
-          changelog-types: '[{"type":"feat","section":"Features","hidden":false},{"type":"fix","section":"Bug Fixes","hidden":false},{"type":"docs","section":"Documentation","hidden":false},{"type":"test","section":"Tests","hidden":false},{"type":"refactor","section":"Refactoring","hidden":false},{"type":"chore","section":"Miscellaneous","hidden":false},{"type":"style","section":"Code Style","hidden":false},{"type":"perf","section":"Performance","hidden":false},{"type":"ci","section":"CI/CD","hidden":false},{"type":"build","section":"Build System","hidden":false}]'
+          # Configuration is now in .release-please-config.json
+          config-file: .release-please-config.json

--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -1,0 +1,20 @@
+{
+  "packages": {
+    ".": {
+      "release-type": "simple",
+      "package-name": "mediaset",
+      "changelog-sections": [
+        {"type": "feat", "section": "Features", "hidden": false},
+        {"type": "fix", "section": "Bug Fixes", "hidden": false},
+        {"type": "docs", "section": "Documentation", "hidden": false},
+        {"type": "test", "section": "Tests", "hidden": false},
+        {"type": "refactor", "section": "Refactoring", "hidden": false},
+        {"type": "chore", "section": "Miscellaneous", "hidden": false},
+        {"type": "style", "section": "Code Style", "hidden": false},
+        {"type": "perf", "section": "Performance", "hidden": false},
+        {"type": "ci", "section": "CI/CD", "hidden": false},
+        {"type": "build", "section": "Build System", "hidden": false}
+      ]
+    }
+  }
+}


### PR DESCRIPTION
- Changed from deprecated google-github-actions/release-please-action to googleapis/release-please-action
- Moved configuration options to .release-please-config.json file
- Removed invalid inputs: bootstrap-sha, package-name, changelog-types
- Configuration now properly uses config-file parameter