### PR TITLE
chore(ci): force initial release as 0.1.0 and pre-major behavior

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -3,6 +3,8 @@
     ".": {
       "release-type": "simple",
       "package-name": "mediaset",
+      "release-as": "0.1.0",
+      "bump-minor-pre-major": true,
       "changelog-sections": [
         {"type": "feat", "section": "Features", "hidden": false},
         {"type": "fix", "section": "Bug Fixes", "hidden": false},


### PR DESCRIPTION
- Set release-as: 0.1.0 for the first release
- Enable bump-minor-pre-major to avoid jumping to 1.0.0 before 1.0
