### PR TITLE
chore(ci): remove release-as config after initial 0.1.0 release [AI-a…

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -3,7 +3,6 @@
     ".": {
       "release-type": "simple",
       "package-name": "mediaset",
-      "release-as": "0.1.0",
       "bump-minor-pre-major": true,
       "changelog-sections": [
         {"type": "feat", "section": "Features", "hidden": false},


### PR DESCRIPTION
…ssisted]

- Removed release-as: 0.1.0 now that initial version has been set
- Keep bump-minor-pre-major to maintain pre-1.0 behavior
- Future releases will follow normal semver bumping based on commits