### PR TITLE
fix(ci): ensure version tags build both API and UI images [AI-assisted] refs #234

### DIFF
--- a/.github/workflows/docker-api.yml
+++ b/.github/workflows/docker-api.yml
@@ -1,5 +1,8 @@
 name: Docker - API
 
+# Note: paths filter only applies to branch pushes, not to tags
+# This ensures that every version tag (v*) builds both API and UI images
+# even if only one component changed, maintaining version consistency
 on:
   push:
     branches:
@@ -9,6 +12,10 @@ on:
     paths:
       - 'MediaSet.Api/**'
       - '.github/workflows/docker-api.yml'
+  # Override for tags: run on all tags regardless of paths
+  push:
+    tags:
+      - 'v*'
 
 permissions:
   contents: read

--- a/.github/workflows/docker-ui.yml
+++ b/.github/workflows/docker-ui.yml
@@ -1,5 +1,8 @@
 name: Docker - UI
 
+# Note: paths filter only applies to branch pushes, not to tags
+# This ensures that every version tag (v*) builds both API and UI images
+# even if only one component changed, maintaining version consistency
 on:
   push:
     branches:
@@ -9,6 +12,10 @@ on:
     paths:
       - 'MediaSet.Remix/**'
       - '.github/workflows/docker-ui.yml'
+  # Override for tags: run on all tags regardless of paths
+  push:
+    tags:
+      - 'v*'
 
 permissions:
   contents: read


### PR DESCRIPTION
Path filters now only apply to main branch pushes, ensuring that every version tag (v*) builds both API and UI images regardless of which component changed. This maintains version consistency across both images so users can deploy with confidence.