### PR TITLE
chore(ci): simplify Docker workflows to only build on version tags [AI-assisted]

### DIFF
--- a/.github/workflows/docker-api.yml
+++ b/.github/workflows/docker-api.yml
@@ -1,12 +1,7 @@
 name: Docker - API
 
-# Note: paths filter only applies to branch pushes, not to tags
-# This ensures that every version tag (v*) builds both API and UI images
-# even if only one component changed, maintaining version consistency
 on:
   push:
-    branches:
-      - main
     tags:
       - 'v*'
 
@@ -17,18 +12,6 @@ permissions:
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
-    # Only filter by paths on main branch, always run on tags
-    if: |
-      startsWith(github.ref, 'refs/tags/v') ||
-      (
-        github.ref == 'refs/heads/main' &&
-        (
-          contains(github.event.head_commit.modified, 'MediaSet.Api/') ||
-          contains(github.event.head_commit.added, 'MediaSet.Api/') ||
-          contains(github.event.head_commit.modified, '.github/workflows/docker-api.yml') ||
-          contains(github.event.head_commit.added, '.github/workflows/docker-api.yml')
-        )
-      )
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -44,8 +27,6 @@ jobs:
             ghcr.io/${{ github.repository_owner }}/mediaset-api
           tags: |
             type=ref,event=tag
-            type=raw,value=edge,enable=${{ github.ref == 'refs/heads/main' }}
-            type=sha,format=short
 
       - name: Login to GHCR
         uses: docker/login-action@v3
@@ -67,7 +48,6 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Add semver convenience tags on release
-        if: startsWith(github.ref, 'refs/tags/v')
         run: |
           VERSION="${GITHUB_REF#refs/tags/v}"
           MAJOR=$(echo "$VERSION" | cut -d. -f1)

--- a/.github/workflows/docker-ui.yml
+++ b/.github/workflows/docker-ui.yml
@@ -1,12 +1,7 @@
 name: Docker - UI
 
-# Note: paths filter only applies to branch pushes, not to tags
-# This ensures that every version tag (v*) builds both API and UI images
-# even if only one component changed, maintaining version consistency
 on:
   push:
-    branches:
-      - main
     tags:
       - 'v*'
 
@@ -17,18 +12,6 @@ permissions:
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
-    # Only filter by paths on main branch, always run on tags
-    if: |
-      startsWith(github.ref, 'refs/tags/v') ||
-      (
-        github.ref == 'refs/heads/main' &&
-        (
-          contains(github.event.head_commit.modified, 'MediaSet.Remix/') ||
-          contains(github.event.head_commit.added, 'MediaSet.Remix/') ||
-          contains(github.event.head_commit.modified, '.github/workflows/docker-ui.yml') ||
-          contains(github.event.head_commit.added, '.github/workflows/docker-ui.yml')
-        )
-      )
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -44,8 +27,6 @@ jobs:
             ghcr.io/${{ github.repository_owner }}/mediaset-ui
           tags: |
             type=ref,event=tag
-            type=raw,value=edge,enable=${{ github.ref == 'refs/heads/main' }}
-            type=sha,format=short
 
       - name: Login to GHCR
         uses: docker/login-action@v3
@@ -67,7 +48,6 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Add semver convenience tags on release
-        if: startsWith(github.ref, 'refs/tags/v')
         run: |
           VERSION="${GITHUB_REF#refs/tags/v}"
           MAJOR=$(echo "$VERSION" | cut -d. -f1)


### PR DESCRIPTION
- Remove per-commit SHA-based image building
- Remove 'edge' tag for main branch
- Only trigger Docker builds on version tags (v*)
- Remove complex path filtering and conditionals
- Keep semver convenience tags (major, minor, latest)

This simplifies the CI/CD pipeline and ensures Docker images are only built for official releases.