### PR TITLE
fix(ci): trigger docker workflows on release events closes #245

### DIFF
--- a/.github/workflows/docker-api.yml
+++ b/.github/workflows/docker-api.yml
@@ -4,6 +4,8 @@ on:
   push:
     tags:
       - 'v*'
+  release:
+    types: [published]
 
 permissions:
   contents: read

--- a/.github/workflows/docker-ui.yml
+++ b/.github/workflows/docker-ui.yml
@@ -4,6 +4,8 @@ on:
   push:
     tags:
       - 'v*'
+  release:
+    types: [published]
 
 permissions:
   contents: read


### PR DESCRIPTION
Docker workflows were not triggering when release-please PRs were merged because release-please creates tags via the GitHub API (as part of creating a release), not via git push. Added release event trigger alongside existing tag push trigger.