### PR TITLE
fix(ci): use tags trigger only for docker workflows refs #245

### DIFF
--- a/.github/workflows/docker-api.yml
+++ b/.github/workflows/docker-api.yml
@@ -4,8 +4,6 @@ on:
   push:
     tags:
       - 'v*'
-  release:
-    types: [published]
 
 permissions:
   contents: read

--- a/.github/workflows/docker-ui.yml
+++ b/.github/workflows/docker-ui.yml
@@ -4,8 +4,6 @@ on:
   push:
     tags:
       - 'v*'
-  release:
-    types: [published]
 
 permissions:
   contents: read


### PR DESCRIPTION
Removed release trigger to prevent duplicate builds. With the PAT configured in release-please, tag pushes work correctly and trigger docker builds. This also allows manual tag pushes to build images.