### PR TITLE
style(ui): adjust button colors to fit theme [AI-assisted] closes #252

### DIFF
--- a/MediaSet.Remix/app/components/book-form.tsx
+++ b/MediaSet.Remix/app/components/book-form.tsx
@@ -88,7 +88,6 @@ export default function BookForm({ book, authors, genres, publishers, formats, i
             type="button"
             onClick={handleLookup}
             disabled={isSubmitting}
-            className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-400 disabled:opacity-50 whitespace-nowrap"
           >
             Lookup
           </button>

--- a/MediaSet.Remix/app/components/game-form.tsx
+++ b/MediaSet.Remix/app/components/game-form.tsx
@@ -84,7 +84,6 @@ export default function GameForm({ game, developers, publishers, genres, formats
             type="button"
             onClick={handleLookup}
             disabled={isSubmitting}
-            className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-400 disabled:opacity-50 whitespace-nowrap"
           >
             Lookup
           </button>

--- a/MediaSet.Remix/app/components/movie-form.tsx
+++ b/MediaSet.Remix/app/components/movie-form.tsx
@@ -87,7 +87,6 @@ export default function MovieForm({ movie, genres, studios, formats, isSubmittin
             type="button"
             onClick={handleLookup}
             disabled={isSubmitting}
-            className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-400 disabled:opacity-50 whitespace-nowrap"
           >
             Lookup
           </button>

--- a/MediaSet.Remix/app/components/music-form.tsx
+++ b/MediaSet.Remix/app/components/music-form.tsx
@@ -115,7 +115,6 @@ export default function MusicForm({ music, genres, formats, labels, isSubmitting
             type="button"
             onClick={handleLookup}
             disabled={isSubmitting}
-            className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-400 disabled:opacity-50 whitespace-nowrap"
           >
             Lookup
           </button>
@@ -138,8 +137,7 @@ export default function MusicForm({ music, genres, formats, labels, isSubmitting
           <label className="block text-sm font-medium text-gray-200">Disc List</label>
           <button 
             type="button" 
-            onClick={addDisc} 
-            className="bg-blue-600 text-white py-1 px-3 rounded-md hover:bg-blue-700 text-sm"
+            onClick={addDisc}
           >
             Add Track
           </button>

--- a/MediaSet.Remix/app/routes/$entity_.add/route.tsx
+++ b/MediaSet.Remix/app/routes/$entity_.add/route.tsx
@@ -130,7 +130,7 @@ export default function Add() {
             <div className="flex flex-row gap-2 mt-6">
               <button 
                 type="submit" 
-                className="flex flex-row gap-2 bg-green-600 text-white py-2 px-4 rounded-md hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-400 focus:ring-offset-2 focus:ring-offset-gray-900 disabled:opacity-50" 
+                className="flex flex-row gap-2" 
                 disabled={isSubmitting}
               >
                 {isSubmitting && <div className="flex items-center"><Spinner /></div>}
@@ -139,7 +139,7 @@ export default function Add() {
               <button 
                 type="button" 
                 onClick={() => navigate(-1)} 
-                className="bg-gray-600 text-white py-2 px-4 rounded-md hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-gray-400 focus:ring-offset-2 focus:ring-offset-gray-900 disabled:opacity-50" 
+                className="secondary" 
                 disabled={isSubmitting}
               >
                 Cancel

--- a/MediaSet.Remix/app/routes/$entity_.lookup/route.tsx
+++ b/MediaSet.Remix/app/routes/$entity_.lookup/route.tsx
@@ -68,7 +68,6 @@ export default function LookupRoute() {
         <button
           type="submit"
           disabled={isSubmitting}
-          className="w-full bg-blue-600 text-white py-2 px-4 rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-400 focus:ring-offset-2 focus:ring-offset-gray-900 disabled:opacity-50"
         >
           {isSubmitting ? "Looking up..." : "Look up"}
         </button>

--- a/MediaSet.Remix/app/tailwind.css
+++ b/MediaSet.Remix/app/tailwind.css
@@ -22,7 +22,7 @@
   }
 
   button:not([class~="link"]) {
-    @apply px-3 py-1 dark:text-slate-300 dark:bg-blue-700 dark:hover:bg-blue-800 dark:disabled:bg-blue-950 rounded bg-white transition-colors
+    @apply px-3 py-1 dark:text-slate-200 dark:bg-blue-600 dark:hover:bg-blue-500 dark:disabled:bg-slate-900 dark:disabled:text-slate-500 rounded bg-white transition-colors
   }
 
   button[class~="text-icon"] {


### PR DESCRIPTION
- Changed default button color from blue-700 to blue-600 for better balance
- Removed inline button styles in favor of global tailwind.css definitions
- All primary buttons now use consistent blue-600 background
- Secondary buttons continue to use gray-600 for distinction
- Improved disabled state styling with better contrast