### PR TITLE
feat(ui): replace browser confirm with HTML dialog [AI-assisted] closes #267

### DIFF
--- a/MediaSet.Remix/app/components/delete-dialog.tsx
+++ b/MediaSet.Remix/app/components/delete-dialog.tsx
@@ -1,0 +1,91 @@
+import { Form } from "@remix-run/react";
+import { useEffect, useRef } from "react";
+import { X } from "lucide-react";
+
+type DeleteDialogProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  entityTitle?: string;
+  deleteAction: string;
+};
+
+export default function DeleteDialog({ isOpen, onClose, entityTitle, deleteAction }: DeleteDialogProps) {
+  const dialogRef = useRef<HTMLDialogElement>(null);
+
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+
+    if (isOpen) {
+      dialog.showModal();
+    } else {
+      dialog.close();
+    }
+  }, [isOpen]);
+
+  const handleCancel = (event: React.MouseEvent) => {
+    event.preventDefault();
+    onClose();
+  };
+
+  const handleBackdropClick = (event: React.MouseEvent<HTMLDialogElement>) => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+
+    const rect = dialog.getBoundingClientRect();
+    const isInDialog = (
+      rect.top <= event.clientY &&
+      event.clientY <= rect.top + rect.height &&
+      rect.left <= event.clientX &&
+      event.clientX <= rect.left + rect.width
+    );
+
+    if (!isInDialog) {
+      onClose();
+    }
+  };
+
+  return (
+    <dialog
+      ref={dialogRef}
+      onClick={handleBackdropClick}
+      className="backdrop:bg-gray-900 backdrop:bg-opacity-60 bg-zinc-800 text-slate-200 rounded-lg shadow-xl p-0 w-full max-w-md"
+    >
+      <div className="flex flex-col">
+        <div className="flex items-center justify-between border-b border-slate-600 p-4">
+          <h2 className="text-xl font-semibold">Confirm Delete</h2>
+          <button
+            onClick={handleCancel}
+            className="secondary"
+            aria-label="Close dialog"
+          >
+            <X size={24} />
+          </button>
+        </div>
+        <div className="p-6">
+          <p className="text-slate-300 mb-6">
+            Are you sure you want to delete {entityTitle ? <strong>{entityTitle}</strong> : "this item"}?
+          </p>
+          <p className="text-slate-400 text-sm mb-6">
+            This action cannot be undone.
+          </p>
+          <div className="flex gap-3 justify-end">
+            <button
+              onClick={handleCancel}
+              className="secondary"
+            >
+              Cancel
+            </button>
+            <Form action={deleteAction} method="post">
+              <button
+                type="submit"
+              >
+                Delete
+              </button>
+            </Form>
+          </div>
+        </div>
+      </div>
+    </dialog>
+  );
+}

--- a/MediaSet.Remix/app/routes/$entity._index/books.tsx
+++ b/MediaSet.Remix/app/routes/$entity._index/books.tsx
@@ -1,5 +1,7 @@
-import { Form, Link } from "@remix-run/react";
+import { Link } from "@remix-run/react";
 import { Pencil, Trash2 } from "lucide-react";
+import { useState } from "react";
+import DeleteDialog from "~/components/delete-dialog";
 import { BookEntity } from "~/models";
 
 type BooksProps = {
@@ -7,8 +9,14 @@ type BooksProps = {
 };
 
 export default function Books({ books }: BooksProps) {
+  const [deleteDialogState, setDeleteDialogState] = useState<{ isOpen: boolean; book: BookEntity | null }>({
+    isOpen: false,
+    book: null
+  });
+
   return (
-    <table className="text-left w-full">
+    <>
+      <table className="text-left w-full">
       <thead className="dark:bg-zinc-700 border-b-2 border-slate-600">
         <tr>
           <th className="pl-2 p-1 border-r border-slate-800 underline">Title</th>
@@ -30,19 +38,27 @@ export default function Books({ books }: BooksProps) {
               <td className="hidden sm:table-cell pl-2 p-1 border-r border-slate-800">{book.pages}</td>
               <td className="flex flex-row gap-3 p-1 pt-2">
                 <Link to={`/books/${book.id}/edit`} aria-label="Edit" title="Edit"><Pencil size={18} /></Link>
-                <Form action={`/books/${book.id}/delete`} method="post" onSubmit={(event) => {
-                  const response = confirm(`Are you sure you want to delete ${book.title}?`);
-                  if (!response) {
-                    event.preventDefault();
-                  }
-                }}>
-                  <button className="link" type="submit" aria-label="Delete" title="Delete"><Trash2 size={18} /></button>
-                </Form>
+                <button
+                  onClick={() => setDeleteDialogState({ isOpen: true, book })}
+                  className="link"
+                  type="button"
+                  aria-label="Delete"
+                  title="Delete"
+                >
+                  <Trash2 size={18} />
+                </button>
               </td>
             </tr>
           )
         })}
       </tbody>
     </table>
+    <DeleteDialog
+      isOpen={deleteDialogState.isOpen}
+      onClose={() => setDeleteDialogState({ isOpen: false, book: null })}
+      entityTitle={deleteDialogState.book?.title}
+      deleteAction={deleteDialogState.book ? `/books/${deleteDialogState.book.id}/delete` : ""}
+    />
+    </>
   )
 }

--- a/MediaSet.Remix/app/routes/$entity._index/games.tsx
+++ b/MediaSet.Remix/app/routes/$entity._index/games.tsx
@@ -1,5 +1,7 @@
-import { Form, Link } from "@remix-run/react";
+import { Link } from "@remix-run/react";
 import { Pencil, Trash2 } from "lucide-react";
+import { useState } from "react";
+import DeleteDialog from "~/components/delete-dialog";
 import { GameEntity } from "~/models";
 
 type GamesProps = {
@@ -7,8 +9,14 @@ type GamesProps = {
 };
 
 export default function Games({ games }: GamesProps) {
+  const [deleteDialogState, setDeleteDialogState] = useState<{ isOpen: boolean; game: GameEntity | null }>({
+    isOpen: false,
+    game: null
+  });
+
   return (
-    <table className="text-left w-full">
+    <>
+      <table className="text-left w-full">
       <thead className="dark:bg-zinc-700 border-b-2 border-slate-600">
         <tr>
           <th className="pl-2 p-1 border-r border-slate-800 underline">Title</th>
@@ -30,19 +38,27 @@ export default function Games({ games }: GamesProps) {
               <td className="hidden sm:table-cell pl-2 p-1 border-r border-slate-800">{game.developers?.map(dev => dev.trimEnd()).join(', ')}</td>
               <td className="flex flex-row gap-3 p-1 pt-2">
                 <Link to={`/games/${game.id}/edit`} aria-label="Edit" title="Edit"><Pencil size={18} /></Link>
-                <Form action={`/games/${game.id}/delete`} method="post" onSubmit={(event) => {
-                  const response = confirm(`Are you sure you want to delete ${game.title}?`);
-                  if (!response) {
-                    event.preventDefault();
-                  }
-                }}>
-                  <button className="link" type="submit" aria-label="Delete" title="Delete"><Trash2 size={18} /></button>
-                </Form>
+                <button
+                  onClick={() => setDeleteDialogState({ isOpen: true, game })}
+                  className="link"
+                  type="button"
+                  aria-label="Delete"
+                  title="Delete"
+                >
+                  <Trash2 size={18} />
+                </button>
               </td>
             </tr>
           )
         })}
       </tbody>
     </table>
+    <DeleteDialog
+      isOpen={deleteDialogState.isOpen}
+      onClose={() => setDeleteDialogState({ isOpen: false, game: null })}
+      entityTitle={deleteDialogState.game?.title}
+      deleteAction={deleteDialogState.game ? `/games/${deleteDialogState.game.id}/delete` : ""}
+    />
+    </>
   )
 }

--- a/MediaSet.Remix/app/routes/$entity._index/movies.tsx
+++ b/MediaSet.Remix/app/routes/$entity._index/movies.tsx
@@ -1,6 +1,8 @@
 
-import { Form, Link } from "@remix-run/react";
+import { Link } from "@remix-run/react";
 import { Pencil, Trash2, Check } from "lucide-react";
+import { useState } from "react";
+import DeleteDialog from "~/components/delete-dialog";
 import { MovieEntity } from "~/models";
 
 type MovieProps = {
@@ -8,8 +10,14 @@ type MovieProps = {
 };
 
 export default function Movies({ movies }: MovieProps) {
+  const [deleteDialogState, setDeleteDialogState] = useState<{ isOpen: boolean; movie: MovieEntity | null }>({
+    isOpen: false,
+    movie: null
+  });
+
   return (
-    <table className="text-left w-full">
+    <>
+      <table className="text-left w-full">
       <thead className="dark:bg-zinc-700 border-b-2 border-slate-600">
         <tr>
           <th className="pl-2 p-1 border-r border-slate-800 underline">Title</th>
@@ -35,19 +43,27 @@ export default function Movies({ movies }: MovieProps) {
               </td>
               <td className="flex flex-row gap-3 p-1 pt-2">
                 <Link to={`/movies/${movie.id}/edit`} aria-label="Edit" title="Edit"><Pencil size={18} /></Link>
-                <Form action={`/movies/${movie.id}/delete`} method="post" onSubmit={(event) => {
-                  const response = confirm(`Are you sure you want to delete ${movie.title}?`);
-                  if (!response) {
-                    event.preventDefault();
-                  }
-                }}>
-                  <button className="link" type="submit" aria-label="Delete" title="Delete"><Trash2 size={18} /></button>
-                </Form>
+                <button
+                  onClick={() => setDeleteDialogState({ isOpen: true, movie })}
+                  className="link"
+                  type="button"
+                  aria-label="Delete"
+                  title="Delete"
+                >
+                  <Trash2 size={18} />
+                </button>
               </td>
             </tr>
           )
         })}
       </tbody>
     </table>
+    <DeleteDialog
+      isOpen={deleteDialogState.isOpen}
+      onClose={() => setDeleteDialogState({ isOpen: false, movie: null })}
+      entityTitle={deleteDialogState.movie?.title}
+      deleteAction={deleteDialogState.movie ? `/movies/${deleteDialogState.movie.id}/delete` : ""}
+    />
+    </>
   )
 }

--- a/MediaSet.Remix/app/routes/$entity._index/musics.tsx
+++ b/MediaSet.Remix/app/routes/$entity._index/musics.tsx
@@ -1,5 +1,7 @@
-import { Form, Link } from "@remix-run/react";
+import { Link } from "@remix-run/react";
 import { Pencil, Trash2 } from "lucide-react";
+import { useState } from "react";
+import DeleteDialog from "~/components/delete-dialog";
 import { MusicEntity } from "~/models";
 
 type MusicsProps = {
@@ -7,8 +9,14 @@ type MusicsProps = {
 };
 
 export default function Musics({ musics }: MusicsProps) {
+  const [deleteDialogState, setDeleteDialogState] = useState<{ isOpen: boolean; music: MusicEntity | null }>({
+    isOpen: false,
+    music: null
+  });
+
   return (
-    <table className="text-left w-full">
+    <>
+      <table className="text-left w-full">
       <thead className="dark:bg-zinc-700 border-b-2 border-slate-600">
         <tr>
           <th className="pl-2 p-1 border-r border-slate-800 underline">Title</th>
@@ -30,19 +38,27 @@ export default function Musics({ musics }: MusicsProps) {
               <td className="hidden sm:table-cell pl-2 p-1 border-r border-slate-800">{music.tracks}</td>
               <td className="flex flex-row gap-3 p-1 pt-2">
                 <Link to={`/musics/${music.id}/edit`} aria-label="Edit" title="Edit"><Pencil size={18} /></Link>
-                <Form action={`/musics/${music.id}/delete`} method="post" onSubmit={(event) => {
-                  const response = confirm(`Are you sure you want to delete ${music.title}?`);
-                  if (!response) {
-                    event.preventDefault();
-                  }
-                }}>
-                  <button className="link" type="submit" aria-label="Delete" title="Delete"><Trash2 size={18} /></button>
-                </Form>
+                <button
+                  onClick={() => setDeleteDialogState({ isOpen: true, music })}
+                  className="link"
+                  type="button"
+                  aria-label="Delete"
+                  title="Delete"
+                >
+                  <Trash2 size={18} />
+                </button>
               </td>
             </tr>
           )
         })}
       </tbody>
     </table>
+    <DeleteDialog
+      isOpen={deleteDialogState.isOpen}
+      onClose={() => setDeleteDialogState({ isOpen: false, music: null })}
+      entityTitle={deleteDialogState.music?.title}
+      deleteAction={deleteDialogState.music ? `/musics/${deleteDialogState.music.id}/delete` : ""}
+    />
+    </>
   )
 }

--- a/MediaSet.Remix/app/routes/$entity_.$entityId/book.tsx
+++ b/MediaSet.Remix/app/routes/$entity_.$entityId/book.tsx
@@ -1,5 +1,7 @@
-import { Form, Link } from "@remix-run/react";
+import { Link } from "@remix-run/react";
 import { Pencil, Trash2 } from "lucide-react";
+import { useState } from "react";
+import DeleteDialog from "~/components/delete-dialog";
 import { BookEntity } from "~/models"
 
 type BookProps = {
@@ -7,6 +9,7 @@ type BookProps = {
 };
 
 export default function Book({ book }: BookProps) {
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
  return (
       <div className="flex flex-col">
         <div className="flex flex-row items-center justify-between border-b-2 border-slate-600 pb-2">
@@ -16,14 +19,15 @@ export default function Book({ book }: BookProps) {
           </div>
           <div className="flex flex-row gap-2">
             <Link to={`/books/${book.id}/edit`} aria-label="Edit" title="Edit"><Pencil size={22} /></Link>
-            <Form action={`/books/${book.id}/delete`} method="post" onSubmit={(event) => {
-              const response = confirm(`Are you sure you want to delete ${book.title}?`);
-              if (!response) {
-                event.preventDefault();
-              }
-            }}>
-              <button className="link" type="submit" aria-label="Delete" title="Delete"><Trash2 size={22} /></button>
-            </Form>
+            <button
+              onClick={() => setIsDeleteDialogOpen(true)}
+              className="link"
+              type="button"
+              aria-label="Delete"
+              title="Delete"
+            >
+              <Trash2 size={22} />
+            </button>
           </div>
         </div>
         <div className="h-full mt-4">
@@ -60,6 +64,12 @@ export default function Book({ book }: BookProps) {
             <div id="plot" className="basis-3/4">{book.plot}</div>
           </div>
         </div>
+        <DeleteDialog
+          isOpen={isDeleteDialogOpen}
+          onClose={() => setIsDeleteDialogOpen(false)}
+          entityTitle={book.title}
+          deleteAction={`/books/${book.id}/delete`}
+        />
       </div>
     );
 }

--- a/MediaSet.Remix/app/routes/$entity_.$entityId/game.tsx
+++ b/MediaSet.Remix/app/routes/$entity_.$entityId/game.tsx
@@ -1,5 +1,7 @@
-import { Form, Link } from "@remix-run/react";
+import { Link } from "@remix-run/react";
 import { Pencil, Trash2 } from "lucide-react";
+import { useState } from "react";
+import DeleteDialog from "~/components/delete-dialog";
 import { GameEntity } from "~/models"
 
 type GameProps = {
@@ -7,6 +9,8 @@ type GameProps = {
 };
 
 export default function Game({ game }: GameProps) {
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+
   return (
     <div className="flex flex-col">
       <div className="flex flex-row items-center justify-between border-b-2 border-slate-600 pb-2">
@@ -15,14 +19,15 @@ export default function Game({ game }: GameProps) {
         </div>
         <div className="flex flex-row gap-2">
           <Link to={`/games/${game.id}/edit`} aria-label="Edit" title="Edit"><Pencil size={22} /></Link>
-          <Form action={`/games/${game.id}/delete`} method="post" onSubmit={(event) => {
-            const response = confirm(`Are you sure you want to delete ${game.title}?`);
-            if (!response) {
-              event.preventDefault();
-            }
-          }}>
-            <button className="link" type="submit" aria-label="Delete" title="Delete"><Trash2 size={22} /></button>
-          </Form>
+          <button
+            onClick={() => setIsDeleteDialogOpen(true)}
+            className="link"
+            type="button"
+            aria-label="Delete"
+            title="Delete"
+          >
+            <Trash2 size={22} />
+          </button>
         </div>
       </div>
       <div className="h-full mt-4">
@@ -63,6 +68,12 @@ export default function Game({ game }: GameProps) {
           <div id="description" className="basis-3/4">{game.description}</div>
         </div>
       </div>
+      <DeleteDialog
+        isOpen={isDeleteDialogOpen}
+        onClose={() => setIsDeleteDialogOpen(false)}
+        entityTitle={game.title}
+        deleteAction={`/games/${game.id}/delete`}
+      />
     </div>
   );
 }

--- a/MediaSet.Remix/app/routes/$entity_.$entityId/movie.tsx
+++ b/MediaSet.Remix/app/routes/$entity_.$entityId/movie.tsx
@@ -1,5 +1,7 @@
-import { Form, Link } from "@remix-run/react";
+import { Link } from "@remix-run/react";
 import { Pencil, Trash2, Check } from "lucide-react";
+import { useState } from "react";
+import DeleteDialog from "~/components/delete-dialog";
 import { MovieEntity } from "~/models"
 
 type MovieProps = {
@@ -7,6 +9,8 @@ type MovieProps = {
 };
 
 export default function Movie({ movie }: MovieProps) {
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+
   return (
     <div className="flex flex-col">
       <div className="flex flex-row items-center justify-between border-b-2 border-slate-600 pb-2">
@@ -15,14 +19,15 @@ export default function Movie({ movie }: MovieProps) {
         </div>
         <div className="flex flex-row gap-2">
           <Link to={`/movies/${movie.id}/edit`} aria-label="Edit" title="Edit"><Pencil size={22} /></Link>
-          <Form action={`/movies/${movie.id}/delete`} method="post" onSubmit={(event) => {
-            const response = confirm(`Are you sure you want to delete ${movie.title}?`);
-            if (!response) {
-              event.preventDefault();
-            }
-          }}>
-            <button className="link" type="submit" aria-label="Delete" title="Delete"><Trash2 size={22} /></button>
-          </Form>
+          <button
+            onClick={() => setIsDeleteDialogOpen(true)}
+            className="link"
+            type="button"
+            aria-label="Delete"
+            title="Delete"
+          >
+            <Trash2 size={22} />
+          </button>
         </div>
       </div>
       <div className="h-full mt-4">
@@ -59,6 +64,12 @@ export default function Movie({ movie }: MovieProps) {
           <div id="plot" className="basis-3/4">{movie.plot}</div>
         </div>
       </div>
+      <DeleteDialog
+        isOpen={isDeleteDialogOpen}
+        onClose={() => setIsDeleteDialogOpen(false)}
+        entityTitle={movie.title}
+        deleteAction={`/movies/${movie.id}/delete`}
+      />
     </div>
   );
 }

--- a/MediaSet.Remix/app/routes/$entity_.$entityId/music.tsx
+++ b/MediaSet.Remix/app/routes/$entity_.$entityId/music.tsx
@@ -1,5 +1,7 @@
-import { Form, Link } from "@remix-run/react";
+import { Link } from "@remix-run/react";
 import { Pencil, Trash2 } from "lucide-react";
+import { useState } from "react";
+import DeleteDialog from "~/components/delete-dialog";
 import { MusicEntity } from "~/models"
 
 type MusicProps = {
@@ -7,6 +9,8 @@ type MusicProps = {
 };
 
 export default function Music({ music }: MusicProps) {
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+
   return (
     <div className="flex flex-col">
       <div className="flex flex-row items-center justify-between border-b-2 border-slate-600 pb-2">
@@ -15,14 +19,15 @@ export default function Music({ music }: MusicProps) {
         </div>
         <div className="flex flex-row gap-2">
           <Link to={`/musics/${music.id}/edit`} aria-label="Edit" title="Edit"><Pencil size={22} /></Link>
-          <Form action={`/musics/${music.id}/delete`} method="post" onSubmit={(event) => {
-            const response = confirm(`Are you sure you want to delete ${music.title}?`);
-            if (!response) {
-              event.preventDefault();
-            }
-          }}>
-            <button className="link" type="submit" aria-label="Delete" title="Delete"><Trash2 size={22} /></button>
-          </Form>
+          <button
+            onClick={() => setIsDeleteDialogOpen(true)}
+            className="link"
+            type="button"
+            aria-label="Delete"
+            title="Delete"
+          >
+            <Trash2 size={22} />
+          </button>
         </div>
       </div>
       <div className="h-full mt-4">
@@ -88,6 +93,12 @@ export default function Music({ music }: MusicProps) {
           </div>
         )}
       </div>
+      <DeleteDialog
+        isOpen={isDeleteDialogOpen}
+        onClose={() => setIsDeleteDialogOpen(false)}
+        entityTitle={music.title}
+        deleteAction={`/musics/${music.id}/delete`}
+      />
     </div>
   );
 }


### PR DESCRIPTION
Replaced all browser confirm() dialogs with a custom HTML dialog component that matches application styling and uses normal Remix form submissions.

- Created reusable DeleteDialog component using HTML dialog element
- Updated all delete operations across books, movies, games, and music
- Dialog uses proper button styles (secondary for cancel/close, primary for delete)
- Maintains full Remix functionality without client-side fetch calls