### PR TITLE
feat(ui): improve entity list mobile layout [AI-assisted] closes #253

### DIFF
--- a/MediaSet.Remix/app/routes/$entity._index/books.tsx
+++ b/MediaSet.Remix/app/routes/$entity._index/books.tsx
@@ -17,48 +17,48 @@ export default function Books({ books }: BooksProps) {
   return (
     <>
       <table className="text-left w-full">
-      <thead className="dark:bg-zinc-700 border-b-2 border-slate-600">
-        <tr>
-          <th className="pl-2 p-1 border-r border-slate-800 underline">Title</th>
-          <th className="pl-2 p-1 border-r border-slate-800 underline">Authors</th>
-          <th className="hidden sm:table-cell pl-2 p-1 border-r border-slate-800 underline">Format</th>
-          <th className="hidden sm:table-cell pl-2 p-1 border-r border-slate-800 underline">Pages</th>
-          <th></th>
-        </tr>
-      </thead>
-      <tbody>
-        {books.map(book => {
-          return (
-            <tr className="border-b border-slate-700 dark:hover:bg-zinc-800" key={book.id}>
-              <td className="pl-2 p-1 border-r border-slate-800">
-                <Link to={`/books/${book.id}`}>{book.title}{book.subtitle && `: ${book.subtitle}`}</Link>
-              </td>
-              <td className="pl-2 p-1 border-r border-slate-800">{book.authors?.map(auth => auth.trimEnd()).join(',')}</td>
-              <td className="hidden sm:table-cell pl-2 p-1 border-r border-slate-800">{book.format}</td>
-              <td className="hidden sm:table-cell pl-2 p-1 border-r border-slate-800">{book.pages}</td>
-              <td className="flex flex-row gap-3 p-1 pt-2">
-                <Link to={`/books/${book.id}/edit`} aria-label="Edit" title="Edit"><Pencil size={18} /></Link>
-                <button
-                  onClick={() => setDeleteDialogState({ isOpen: true, book })}
-                  className="link"
-                  type="button"
-                  aria-label="Delete"
-                  title="Delete"
-                >
-                  <Trash2 size={18} />
-                </button>
-              </td>
-            </tr>
-          )
-        })}
-      </tbody>
-    </table>
-    <DeleteDialog
-      isOpen={deleteDialogState.isOpen}
-      onClose={() => setDeleteDialogState({ isOpen: false, book: null })}
-      entityTitle={deleteDialogState.book?.title}
-      deleteAction={deleteDialogState.book ? `/books/${deleteDialogState.book.id}/delete` : ""}
-    />
+        <thead className="dark:bg-zinc-700 border-b-2 border-slate-600">
+          <tr>
+            <th className="pl-2 p-1 border-r border-slate-800 underline">Title</th>
+            <th className="hidden xs:table-cell pl-2 p-1 border-r border-slate-800 underline">Authors</th>
+            <th className="hidden md:table-cell pl-2 p-1 border-r border-slate-800 underline">Format</th>
+            <th className="hidden lg:table-cell pl-2 p-1 border-r border-slate-800 underline">Pages</th>
+            <th className="w-1"></th>
+          </tr>
+        </thead>
+        <tbody>
+          {books.map(book => {
+            return (
+              <tr className="border-b border-slate-700 dark:hover:bg-zinc-800" key={book.id}>
+                <td className="pl-2 p-1 border-r border-slate-800">
+                  <Link to={`/books/${book.id}`}>{book.title}{book.subtitle && `: ${book.subtitle}`}</Link>
+                </td>
+                <td className="hidden xs:table-cell pl-2 p-1 border-r border-slate-800">{book.authors?.map(auth => auth.trimEnd()).join(',')}</td>
+                <td className="hidden md:table-cell pl-2 p-1 border-r border-slate-800">{book.format}</td>
+                <td className="hidden lg:table-cell pl-2 p-1 border-r border-slate-800">{book.pages}</td>
+                <td className="flex flex-row gap-3 p-1 pt-2">
+                  <Link to={`/books/${book.id}/edit`} aria-label="Edit" title="Edit"><Pencil size={18} /></Link>
+                  <button
+                    onClick={() => setDeleteDialogState({ isOpen: true, book })}
+                    className="link"
+                    type="button"
+                    aria-label="Delete"
+                    title="Delete"
+                  >
+                    <Trash2 size={18} />
+                  </button>
+                </td>
+              </tr>
+            )
+          })}
+        </tbody>
+      </table>
+      <DeleteDialog
+        isOpen={deleteDialogState.isOpen}
+        onClose={() => setDeleteDialogState({ isOpen: false, book: null })}
+        entityTitle={deleteDialogState.book?.title}
+        deleteAction={deleteDialogState.book ? `/books/${deleteDialogState.book.id}/delete` : ""}
+      />
     </>
   )
 }

--- a/MediaSet.Remix/app/routes/$entity._index/games.tsx
+++ b/MediaSet.Remix/app/routes/$entity._index/games.tsx
@@ -17,48 +17,48 @@ export default function Games({ games }: GamesProps) {
   return (
     <>
       <table className="text-left w-full">
-      <thead className="dark:bg-zinc-700 border-b-2 border-slate-600">
-        <tr>
-          <th className="pl-2 p-1 border-r border-slate-800 underline">Title</th>
-          <th className="hidden sm:table-cell pl-2 p-1 border-r border-slate-800 underline">Platform</th>
-          <th className="hidden sm:table-cell pl-2 p-1 border-r border-slate-800 underline">Format</th>
-          <th className="hidden sm:table-cell pl-2 p-1 border-r border-slate-800 underline">Developers</th>
-          <th></th>
-        </tr>
-      </thead>
-      <tbody>
-        {games.map(game => {
-          return (
-            <tr className="border-b border-slate-700 dark:hover:bg-zinc-800" key={game.id}>
-              <td className="pl-2 p-1 border-r border-slate-800">
-                <Link to={`/games/${game.id}`}>{game.title}</Link>
-              </td>
-              <td className="hidden sm:table-cell pl-2 p-1 border-r border-slate-800">{game.platform}</td>
-              <td className="hidden sm:table-cell pl-2 p-1 border-r border-slate-800">{game.format}</td>
-              <td className="hidden sm:table-cell pl-2 p-1 border-r border-slate-800">{game.developers?.map(dev => dev.trimEnd()).join(', ')}</td>
-              <td className="flex flex-row gap-3 p-1 pt-2">
-                <Link to={`/games/${game.id}/edit`} aria-label="Edit" title="Edit"><Pencil size={18} /></Link>
-                <button
-                  onClick={() => setDeleteDialogState({ isOpen: true, game })}
-                  className="link"
-                  type="button"
-                  aria-label="Delete"
-                  title="Delete"
-                >
-                  <Trash2 size={18} />
-                </button>
-              </td>
-            </tr>
-          )
-        })}
-      </tbody>
-    </table>
-    <DeleteDialog
-      isOpen={deleteDialogState.isOpen}
-      onClose={() => setDeleteDialogState({ isOpen: false, game: null })}
-      entityTitle={deleteDialogState.game?.title}
-      deleteAction={deleteDialogState.game ? `/games/${deleteDialogState.game.id}/delete` : ""}
-    />
+        <thead className="dark:bg-zinc-700 border-b-2 border-slate-600">
+          <tr>
+            <th className="pl-2 p-1 border-r border-slate-800 underline">Title</th>
+            <th className="hidden md:table-cell pl-2 p-1 border-r border-slate-800 underline">Platform</th>
+            <th className="hidden lg:table-cell pl-2 p-1 border-r border-slate-800 underline">Format</th>
+            <th className="hidden xl:table-cell pl-2 p-1 border-r border-slate-800 underline">Developers</th>
+            <th className="w-1"></th>
+          </tr>
+        </thead>
+        <tbody>
+          {games.map(game => {
+            return (
+              <tr className="border-b border-slate-700 dark:hover:bg-zinc-800" key={game.id}>
+                <td className="pl-2 p-1 border-r border-slate-800">
+                  <Link to={`/games/${game.id}`}>{game.title}</Link>
+                </td>
+                <td className="hidden md:table-cell pl-2 p-1 border-r border-slate-800">{game.platform}</td>
+                <td className="hidden lg:table-cell pl-2 p-1 border-r border-slate-800">{game.format}</td>
+                <td className="hidden xl:table-cell pl-2 p-1 border-r border-slate-800">{game.developers?.map(dev => dev.trimEnd()).join(', ')}</td>
+                <td className="flex flex-row gap-3 p-1 pt-2">
+                  <Link to={`/games/${game.id}/edit`} aria-label="Edit" title="Edit"><Pencil size={18} /></Link>
+                  <button
+                    onClick={() => setDeleteDialogState({ isOpen: true, game })}
+                    className="link"
+                    type="button"
+                    aria-label="Delete"
+                    title="Delete"
+                  >
+                    <Trash2 size={18} />
+                  </button>
+                </td>
+              </tr>
+            )
+          })}
+        </tbody>
+      </table>
+      <DeleteDialog
+        isOpen={deleteDialogState.isOpen}
+        onClose={() => setDeleteDialogState({ isOpen: false, game: null })}
+        entityTitle={deleteDialogState.game?.title}
+        deleteAction={deleteDialogState.game ? `/games/${deleteDialogState.game.id}/delete` : ""}
+      />
     </>
   )
 }

--- a/MediaSet.Remix/app/routes/$entity._index/movies.tsx
+++ b/MediaSet.Remix/app/routes/$entity._index/movies.tsx
@@ -18,52 +18,52 @@ export default function Movies({ movies }: MovieProps) {
   return (
     <>
       <table className="text-left w-full">
-      <thead className="dark:bg-zinc-700 border-b-2 border-slate-600">
-        <tr>
-          <th className="pl-2 p-1 border-r border-slate-800 underline">Title</th>
-          <th className="hidden sm:table-cell pl-2 p-1 border-r border-slate-800 underline">Format</th>
-          <th className="hidden sm:table-cell pl-2 p-1 border-r border-slate-800 underline">Runtime</th>
-          <th className="hidden sm:table-cell pl-2 p-1 border-r border-slate-800 underline">TV Show</th>
-          <th></th>
-        </tr>
-      </thead>
-      <tbody>
-        {movies.map(movie => {
-          return (
-            <tr className="border-b border-slate-700 dark:hover:bg-zinc-800" key={movie.id}>
-              <td className="pl-2 p-1 border-r border-slate-800">
-                <Link to={`/movies/${movie.id}`}>{movie.title}</Link>
-              </td>
-              <td className="hidden sm:table-cell pl-2 p-1 border-r border-slate-800">{movie.format}</td>
-              <td className="hidden sm:table-cell pl-2 p-1 border-r border-slate-800">{movie.runtime ?? 0}</td>
-              <td className="hidden sm:table-cell pl-2 p-1 border-r border-slate-800">
-                <div className="flex justify-center">
-                  {movie.isTvSeries && <Check size={18} />}
-                </div>
-              </td>
-              <td className="flex flex-row gap-3 p-1 pt-2">
-                <Link to={`/movies/${movie.id}/edit`} aria-label="Edit" title="Edit"><Pencil size={18} /></Link>
-                <button
-                  onClick={() => setDeleteDialogState({ isOpen: true, movie })}
-                  className="link"
-                  type="button"
-                  aria-label="Delete"
-                  title="Delete"
-                >
-                  <Trash2 size={18} />
-                </button>
-              </td>
-            </tr>
-          )
-        })}
-      </tbody>
-    </table>
-    <DeleteDialog
-      isOpen={deleteDialogState.isOpen}
-      onClose={() => setDeleteDialogState({ isOpen: false, movie: null })}
-      entityTitle={deleteDialogState.movie?.title}
-      deleteAction={deleteDialogState.movie ? `/movies/${deleteDialogState.movie.id}/delete` : ""}
-    />
+        <thead className="dark:bg-zinc-700 border-b-2 border-slate-600">
+          <tr>
+            <th className="pl-2 p-1 border-r border-slate-800 underline">Title</th>
+            <th className="hidden md:table-cell pl-2 p-1 border-r border-slate-800 underline">Format</th>
+            <th className="hidden lg:table-cell pl-2 p-1 border-r border-slate-800 underline">Runtime</th>
+            <th className="hidden xl:table-cell pl-2 p-1 border-r border-slate-800 underline">TV Show</th>
+            <th className="w-1"></th>
+          </tr>
+        </thead>
+        <tbody>
+          {movies.map(movie => {
+            return (
+              <tr className="border-b border-slate-700 dark:hover:bg-zinc-800" key={movie.id}>
+                <td className="pl-2 p-1 border-r border-slate-800">
+                  <Link to={`/movies/${movie.id}`}>{movie.title}</Link>
+                </td>
+                <td className="hidden md:table-cell pl-2 p-1 border-r border-slate-800">{movie.format}</td>
+                <td className="hidden lg:table-cell pl-2 p-1 border-r border-slate-800">{movie.runtime ?? 0}</td>
+                <td className="hidden xl:table-cell pl-2 p-1 border-r border-slate-800">
+                  <div className="flex justify-center">
+                    {movie.isTvSeries && <Check size={16} />}
+                  </div>
+                </td>
+                <td className="flex flex-row gap-3 p-1 pt-2">
+                  <Link to={`/movies/${movie.id}/edit`} aria-label="Edit" title="Edit"><Pencil size={18} /></Link>
+                  <button
+                    onClick={() => setDeleteDialogState({ isOpen: true, movie })}
+                    className="link"
+                    type="button"
+                    aria-label="Delete"
+                    title="Delete"
+                  >
+                    <Trash2 size={18} />
+                  </button>
+                </td>
+              </tr>
+            )
+          })}
+        </tbody>
+      </table>
+      <DeleteDialog
+        isOpen={deleteDialogState.isOpen}
+        onClose={() => setDeleteDialogState({ isOpen: false, movie: null })}
+        entityTitle={deleteDialogState.movie?.title}
+        deleteAction={deleteDialogState.movie ? `/movies/${deleteDialogState.movie.id}/delete` : ""}
+      />
     </>
   )
 }

--- a/MediaSet.Remix/app/routes/$entity._index/musics.tsx
+++ b/MediaSet.Remix/app/routes/$entity._index/musics.tsx
@@ -17,48 +17,48 @@ export default function Musics({ musics }: MusicsProps) {
   return (
     <>
       <table className="text-left w-full">
-      <thead className="dark:bg-zinc-700 border-b-2 border-slate-600">
-        <tr>
-          <th className="pl-2 p-1 border-r border-slate-800 underline">Title</th>
-          <th className="pl-2 p-1 border-r border-slate-800 underline">Artist</th>
-          <th className="hidden sm:table-cell pl-2 p-1 border-r border-slate-800 underline">Format</th>
-          <th className="hidden sm:table-cell pl-2 p-1 border-r border-slate-800 underline">Tracks</th>
-          <th></th>
-        </tr>
-      </thead>
-      <tbody>
-        {musics.map(music => {
-          return (
-            <tr className="border-b border-slate-700 dark:hover:bg-zinc-800" key={music.id}>
-              <td className="pl-2 p-1 border-r border-slate-800">
-                <Link to={`/musics/${music.id}`}>{music.title}</Link>
-              </td>
-              <td className="pl-2 p-1 border-r border-slate-800">{music.artist}</td>
-              <td className="hidden sm:table-cell pl-2 p-1 border-r border-slate-800">{music.format}</td>
-              <td className="hidden sm:table-cell pl-2 p-1 border-r border-slate-800">{music.tracks}</td>
-              <td className="flex flex-row gap-3 p-1 pt-2">
-                <Link to={`/musics/${music.id}/edit`} aria-label="Edit" title="Edit"><Pencil size={18} /></Link>
-                <button
-                  onClick={() => setDeleteDialogState({ isOpen: true, music })}
-                  className="link"
-                  type="button"
-                  aria-label="Delete"
-                  title="Delete"
-                >
-                  <Trash2 size={18} />
-                </button>
-              </td>
-            </tr>
-          )
-        })}
-      </tbody>
-    </table>
-    <DeleteDialog
-      isOpen={deleteDialogState.isOpen}
-      onClose={() => setDeleteDialogState({ isOpen: false, music: null })}
-      entityTitle={deleteDialogState.music?.title}
-      deleteAction={deleteDialogState.music ? `/musics/${deleteDialogState.music.id}/delete` : ""}
-    />
+        <thead className="dark:bg-zinc-700 border-b-2 border-slate-600">
+          <tr>
+            <th className="pl-2 p-1 border-r border-slate-800 underline">Title</th>
+            <th className="hidden md:table-cell pl-2 p-1 border-r border-slate-800 underline">Artist</th>
+            <th className="hidden lg:table-cell pl-2 p-1 border-r border-slate-800 underline">Format</th>
+            <th className="hidden xl:table-cell pl-2 p-1 border-r border-slate-800 underline">Tracks</th>
+            <th className="w-1"></th>
+          </tr>
+        </thead>
+        <tbody>
+          {musics.map(music => {
+            return (
+              <tr className="border-b border-slate-700 dark:hover:bg-zinc-800" key={music.id}>
+                <td className="pl-2 p-1 border-r border-slate-800">
+                  <Link to={`/musics/${music.id}`}>{music.title}</Link>
+                </td>
+                <td className="hidden md:table-cell pl-2 p-1 border-r border-slate-800">{music.artist}</td>
+                <td className="hidden lg:table-cell pl-2 p-1 border-r border-slate-800">{music.format}</td>
+                <td className="hidden xl:table-cell pl-2 p-1 border-r border-slate-800">{music.tracks}</td>
+                <td className="flex flex-row gap-3 p-1 pt-2">
+                  <Link to={`/musics/${music.id}/edit`} aria-label="Edit" title="Edit"><Pencil size={18} /></Link>
+                  <button
+                    onClick={() => setDeleteDialogState({ isOpen: true, music })}
+                    className="link"
+                    type="button"
+                    aria-label="Delete"
+                    title="Delete"
+                  >
+                    <Trash2 size={18} />
+                  </button>
+                </td>
+              </tr>
+            )
+          })}
+        </tbody>
+      </table>
+      <DeleteDialog
+        isOpen={deleteDialogState.isOpen}
+        onClose={() => setDeleteDialogState({ isOpen: false, music: null })}
+        entityTitle={deleteDialogState.music?.title}
+        deleteAction={deleteDialogState.music ? `/musics/${deleteDialogState.music.id}/delete` : ""}
+      />
     </>
   )
 }

--- a/MediaSet.Remix/app/routes/$entity/route.tsx
+++ b/MediaSet.Remix/app/routes/$entity/route.tsx
@@ -35,14 +35,14 @@ export default function Index() {
 
   return (
     <div className="flex flex-col px-2">
-      <div className="flex flex-col sm:flex-row gap-2 sm:gap-0 sm:items-center justify-between">
-        <div className="flex flex-row gap-4 items-end">
-          <h2 className="text-2xl">{entityName}</h2>
-        </div>
-        <div className="flex flex-col sm:flex-row gap-2 sm:gap-6 sm:items-center">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex flex-row items-center gap-2">
+          <h2 className="text-2xl mb-1 sm:mb-0">{entityName}</h2>
           <Link to={`/${entityName.toLowerCase()}/add`} className="flex gap-1 items-center"><Plus size={18} /> Add</Link>
-          <Form id="search-form" role="search" className="flex gap-2">
-            <div className="flex gap-0 z-20">
+        </div>
+        <div className="flex flex-row w-full sm:w-auto gap-2 items-center">
+          <Form id="search-form" role="search" className="flex flex-1 sm:flex-none gap-2">
+            <div className="flex flex-1 gap-0 z-20">
               <input
                 id="search"
                 type="search"


### PR DESCRIPTION
- Add/Search controls now appear on a single line on mobile
- Non-essential columns are hidden for smaller screens
- Edit/delete actions are more compact and mobile-friendly