### PR TITLE
fix(api): fix game clean title to remove extra info closes #272

### DIFF
--- a/MediaSet.Api.Tests/Services/GameLookupStrategyTests.cs
+++ b/MediaSet.Api.Tests/Services/GameLookupStrategyTests.cs
@@ -385,6 +385,127 @@ public class GameLookupStrategyTests
 
     #endregion
 
+    #region CleanGameTitleAndExtractEdition
+
+    [Test]
+    public void CleanGameTitleAndExtractEdition_RemovesPrePlayed()
+    {
+        var (cleanedTitle, edition) = GameLookupStrategy.CleanGameTitleAndExtractEdition("Black - Pre-Played");
+
+        Assert.That(cleanedTitle, Is.EqualTo("Black"));
+        Assert.That(edition, Is.Empty);
+    }
+
+    [Test]
+    public void CleanGameTitleAndExtractEdition_RemovesGreatestHits()
+    {
+        var (cleanedTitle, edition) = GameLookupStrategy.CleanGameTitleAndExtractEdition("Heavy Rain - Greatest Hits");
+
+        Assert.That(cleanedTitle, Is.EqualTo("Heavy Rain"));
+        Assert.That(edition, Is.Empty);
+    }
+
+    [Test]
+    public void CleanGameTitleAndExtractEdition_RemovesPreOwned()
+    {
+        var (cleanedTitle, edition) = GameLookupStrategy.CleanGameTitleAndExtractEdition("God of War - Pre-Owned");
+
+        Assert.That(cleanedTitle, Is.EqualTo("God of War"));
+        Assert.That(edition, Is.Empty);
+    }
+
+    [Test]
+    public void CleanGameTitleAndExtractEdition_RemovesPlatinumHits()
+    {
+        var (cleanedTitle, edition) = GameLookupStrategy.CleanGameTitleAndExtractEdition("Halo 3 - Platinum Hits");
+
+        Assert.That(cleanedTitle, Is.EqualTo("Halo 3"));
+        Assert.That(edition, Is.Empty);
+    }
+
+    [Test]
+    public void CleanGameTitleAndExtractEdition_RemovesPlayersChoice()
+    {
+        var (cleanedTitle, edition) = GameLookupStrategy.CleanGameTitleAndExtractEdition("Super Smash Bros - Player's Choice");
+
+        Assert.That(cleanedTitle, Is.EqualTo("Super Smash Bros"));
+        Assert.That(edition, Is.Empty);
+    }
+
+    [Test]
+    public void CleanGameTitleAndExtractEdition_RemovesNintendoSelects()
+    {
+        var (cleanedTitle, edition) = GameLookupStrategy.CleanGameTitleAndExtractEdition("Mario Kart 7 - Nintendo Selects");
+
+        Assert.That(cleanedTitle, Is.EqualTo("Mario Kart 7"));
+        Assert.That(edition, Is.Empty);
+    }
+
+    [Test]
+    public void CleanGameTitleAndExtractEdition_RemovesUsed()
+    {
+        var (cleanedTitle, edition) = GameLookupStrategy.CleanGameTitleAndExtractEdition("The Last of Us - Used");
+
+        Assert.That(cleanedTitle, Is.EqualTo("The Last of Us"));
+        Assert.That(edition, Is.Empty);
+    }
+
+    [Test]
+    public void CleanGameTitleAndExtractEdition_RemovesEssentials()
+    {
+        var (cleanedTitle, edition) = GameLookupStrategy.CleanGameTitleAndExtractEdition("Uncharted - Essentials");
+
+        Assert.That(cleanedTitle, Is.EqualTo("Uncharted"));
+        Assert.That(edition, Is.Empty);
+    }
+
+    [Test]
+    public void CleanGameTitleAndExtractEdition_ExtractsDeluxeEdition()
+    {
+        var (cleanedTitle, edition) = GameLookupStrategy.CleanGameTitleAndExtractEdition("Cyberpunk 2077 Deluxe Edition");
+
+        Assert.That(cleanedTitle, Is.EqualTo("Cyberpunk 2077"));
+        Assert.That(edition, Is.EqualTo("Deluxe"));
+    }
+
+    [Test]
+    public void CleanGameTitleAndExtractEdition_RemovesPlatformIndicators()
+    {
+        var (cleanedTitle, edition) = GameLookupStrategy.CleanGameTitleAndExtractEdition("Spider-Man - PS5");
+
+        Assert.That(cleanedTitle, Is.EqualTo("Spider-Man"));
+        Assert.That(edition, Is.Empty);
+    }
+
+    [Test]
+    public void CleanGameTitleAndExtractEdition_HandlesComplexTitle()
+    {
+        var (cleanedTitle, edition) = GameLookupStrategy.CleanGameTitleAndExtractEdition("Red Dead Redemption 2 - PlayStation 4 - Pre-Played");
+
+        Assert.That(cleanedTitle, Is.EqualTo("Red Dead Redemption 2"));
+        Assert.That(edition, Is.Empty);
+    }
+
+    [Test]
+    public void CleanGameTitleAndExtractEdition_HandlesEmptyString()
+    {
+        var (cleanedTitle, edition) = GameLookupStrategy.CleanGameTitleAndExtractEdition("");
+
+        Assert.That(cleanedTitle, Is.Empty);
+        Assert.That(edition, Is.Empty);
+    }
+
+    [Test]
+    public void CleanGameTitleAndExtractEdition_HandlesWhitespace()
+    {
+        var (cleanedTitle, edition) = GameLookupStrategy.CleanGameTitleAndExtractEdition("   ");
+
+        Assert.That(cleanedTitle, Is.Empty);
+        Assert.That(edition, Is.Empty);
+    }
+
+    #endregion
+
     #region Helpers
 
     private static UpcItemResponse CreateUpcItemResponse(string code, string title, string? category, string? brand, string? model)

--- a/MediaSet.Api/Services/GameLookupStrategy.cs
+++ b/MediaSet.Api/Services/GameLookupStrategy.cs
@@ -110,15 +110,19 @@ public class GameLookupStrategy : ILookupStrategy<GameResponse>
             edition = editionMatch.Value;
         }
 
-    // Remove platform indicators commonly found in UPC titles
-    title = Regex.Replace(title, @"(?i)\b(PS5|PS4|PlayStation 5|PlayStation 4|PlayStation|Xbox Series X\|S|Xbox Series X|Xbox One|Xbox 360|Xbox|Nintendo Switch|Switch|Wii U|Wii|3DS|DS)\b", string.Empty);
+        // Remove platform indicators commonly found in UPC titles
+        title = Regex.Replace(title, @"(?i)\b(PS5|PS4|PlayStation 5|PlayStation 4|PlayStation|Xbox Series X\|S|Xbox Series X|Xbox One|Xbox 360|Xbox|Nintendo Switch|Switch|Wii U|Wii|3DS|DS)\b", string.Empty);
 
-    // Remove format markers like (Cartridge), [Disc], - Disc and trailing dashes
+        // Remove format markers like (Cartridge), [Disc], - Disc and trailing dashes
         title = Regex.Replace(title, @"\s*\([^)]*(Disc|Cartridge|Digital)[^)]*\)", string.Empty, RegexOptions.IgnoreCase);
         title = Regex.Replace(title, @"\s*\[[^\]]*(Disc|Cartridge|Digital)[^\]]*\]", string.Empty, RegexOptions.IgnoreCase);
-    title = Regex.Replace(title, @"\s*-\s*(Disc|Cartridge|Digital).*$", string.Empty, RegexOptions.IgnoreCase);
-    // Remove trailing hyphens left by platform removal
-    title = Regex.Replace(title, @"\s*-\s*$", string.Empty);
+        title = Regex.Replace(title, @"\s*-\s*(Disc|Cartridge|Digital).*$", string.Empty, RegexOptions.IgnoreCase);
+    
+        // Remove common condition/release type suffixes
+        title = Regex.Replace(title, @"\s*-\s*(Pre-Played|Pre-Owned|Used|Greatest Hits|Platinum Hits|Player's Choice|Nintendo Selects|Essentials).*$", string.Empty, RegexOptions.IgnoreCase);
+        
+        // Remove trailing hyphens left by platform removal
+        title = Regex.Replace(title, @"\s*-\s*$", string.Empty);
 
         // Remove trailing SKU-like codes
         title = Regex.Replace(title, @"\b[A-Z0-9]{3,}-[A-Z0-9]{2,}\b", string.Empty);
@@ -126,6 +130,8 @@ public class GameLookupStrategy : ILookupStrategy<GameResponse>
         // Remove extra edition words from title for search
         if (!string.IsNullOrEmpty(edition))
         {
+            // Also remove "Edition" word if it appears after the edition type
+            title = Regex.Replace(title, Regex.Escape(edition) + @"\s*Edition", string.Empty, RegexOptions.IgnoreCase);
             title = Regex.Replace(title, Regex.Escape(edition), string.Empty, RegexOptions.IgnoreCase);
         }
 

--- a/docker-compose.podman.yml
+++ b/docker-compose.podman.yml
@@ -34,6 +34,8 @@ services:
       - OpenLibraryConfiguration__BaseUrl=https://openlibrary.org/
       - TmdbConfiguration__BearerToken=${TMDB_BEARER_TOKEN}
       - UpcItemDbConfiguration__ApiKey=${UPCITEMDB_API_KEY}
+      - GiantBombConfiguration__BaseUrl=${GIANTBOMB_BASE_URL:-https://www.giantbomb.com/api/}
+      - GiantBombConfiguration__ApiKey=${GIANTBOMB_API_KEY}
     volumes:
       - ./MediaSet.Api:/app:Z
       - ~/.nuget/packages:/root/.nuget/packages:Z


### PR DESCRIPTION
Also fixes missing GiantBomb API configuration in docker-compose.podman.yml that prevented .env file from being used when running with Podman.