### PR TITLE
fix(docker): include .git directory for MinVer versioning in production builds closes #281

### DIFF
--- a/MediaSet.Api/Dockerfile
+++ b/MediaSet.Api/Dockerfile
@@ -2,6 +2,9 @@
 FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
 WORKDIR /src
 
+# Copy git directory for MinVer version detection
+COPY .git ./.git
+
 # Copy global.json and solution file
 COPY global.json ./
 COPY MediaSet.sln ./

--- a/MediaSet.Remix/.env.local
+++ b/MediaSet.Remix/.env.local
@@ -1,0 +1,1 @@
+VITE_APP_VERSION=1.0.0-2-gf51efbb-local

--- a/MediaSet.Remix/Dockerfile
+++ b/MediaSet.Remix/Dockerfile
@@ -12,9 +12,9 @@ RUN npm ci && \
 # Copy source code
 COPY . .
 
-# Build argument for versioning
-ARG APP_VERSION=0.0.0-local
-ENV VITE_APP_VERSION=${APP_VERSION}
+# Build argument for versioning - must match what's passed from CI/CD
+ARG VITE_APP_VERSION=0.0.0-local
+ENV VITE_APP_VERSION=${VITE_APP_VERSION}
 
 # Build the application
 RUN npm run build


### PR DESCRIPTION
Copy .git directory into API Docker build so MinVer can access git tags and correctly determine the version. Without this, MinVer defaults to 0.0.0-alpha.0.

Fix UI Dockerfile to use VITE_APP_VERSION for build arg, matching what CI/CD passes. Previously used APP_VERSION which caused version mismatch.

This ensures both API and UI correctly display the version from git tags in production container builds.

[AI-assisted]