### PR TITLE
fix(docker): pass version via build arg instead of copying .git refs #281

### DIFF
--- a/.github/workflows/docker-api.yml
+++ b/.github/workflows/docker-api.yml
@@ -15,9 +15,19 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+
+      - name: Extract version from tag
+        id: version
+        run: |
+          VERSION=${{ github.ref_name }}
+          # Remove 'v' prefix if present
+          VERSION=${VERSION#v}
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
 
       - name: Docker meta
         id: meta
@@ -44,6 +54,8 @@ jobs:
           context: .
           file: MediaSet.Api/Dockerfile
           platforms: linux/amd64
+          build-args: |
+            MINVER_VERSION=${{ steps.version.outputs.version }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/MediaSet.Api/Dockerfile
+++ b/MediaSet.Api/Dockerfile
@@ -2,8 +2,8 @@
 FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
 WORKDIR /src
 
-# Copy git directory for MinVer version detection
-COPY .git ./.git
+# Accept version from build args (passed by CI/CD)
+ARG MINVER_VERSION=""
 
 # Copy global.json and solution file
 COPY global.json ./
@@ -18,7 +18,11 @@ COPY MediaSet.Api/ ./MediaSet.Api/
 
 # Build and publish
 WORKDIR /src/MediaSet.Api
-RUN dotnet publish -c Release -o /app/publish --no-restore
+RUN if [ -n "$MINVER_VERSION" ]; then \
+      dotnet publish -c Release -o /app/publish --no-restore -p:MinVer.Version=$MINVER_VERSION; \
+    else \
+      dotnet publish -c Release -o /app/publish --no-restore; \
+    fi
 
 # Runtime stage
 FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS runtime

--- a/MediaSet.Remix/.env.local
+++ b/MediaSet.Remix/.env.local
@@ -1,1 +1,0 @@
-VITE_APP_VERSION=1.0.0-2-gf51efbb-local


### PR DESCRIPTION
Previous approach tried to copy .git directory into Docker build context, which fails because docker/build-push-action doesn't include it by default.

Instead, extract version from git tag in CI/CD workflow and pass it as a build argument (MINVER_VERSION) to the Dockerfile. The build conditionally applies the version using MinVer's -p:MinVer.Version property when available.

This ensures the API version is correctly set in production builds regardless of whether git information is available in the container.

[AI-assisted]