### PR TITLE
fix(docker): wrap shell conditional in /bin/sh for compatibility refs #281

### DIFF
--- a/MediaSet.Api/Dockerfile
+++ b/MediaSet.Api/Dockerfile
@@ -18,11 +18,11 @@ COPY MediaSet.Api/ ./MediaSet.Api/
 
 # Build and publish
 WORKDIR /src/MediaSet.Api
-RUN if [ -n "$MINVER_VERSION" ]; then \
+RUN /bin/sh -c 'if [ -n "$MINVER_VERSION" ]; then \
       dotnet publish -c Release -o /app/publish --no-restore -p:MinVer.Version=$MINVER_VERSION; \
     else \
       dotnet publish -c Release -o /app/publish --no-restore; \
-    fi
+    fi'
 
 # Runtime stage
 FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS runtime


### PR DESCRIPTION
The if/else conditional in the RUN command needs explicit shell invocation for proper parsing in all Docker base images. Wrap the command with /bin/sh -c to ensure compatibility.

[AI-assisted]