### PR TITLE
fix(docker): simplify minver version handling refs #281

### DIFF
--- a/MediaSet.Api/Dockerfile
+++ b/MediaSet.Api/Dockerfile
@@ -3,7 +3,7 @@ FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
 WORKDIR /src
 
 # Accept version from build args (passed by CI/CD)
-ARG MINVER_VERSION=""
+ARG MINVER_VERSION=0.0.0
 
 # Copy global.json and solution file
 COPY global.json ./
@@ -18,11 +18,7 @@ COPY MediaSet.Api/ ./MediaSet.Api/
 
 # Build and publish
 WORKDIR /src/MediaSet.Api
-RUN /bin/sh -c 'if [ -n "$MINVER_VERSION" ]; then \
-      dotnet publish -c Release -o /app/publish --no-restore -p:MinVer.Version=$MINVER_VERSION; \
-    else \
-      dotnet publish -c Release -o /app/publish --no-restore; \
-    fi'
+RUN dotnet publish -c Release -o /app/publish --no-restore -p:MinVer.Version=$MINVER_VERSION
 
 # Runtime stage
 FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS runtime


### PR DESCRIPTION
Default MINVER_VERSION to 0.0.0 and always pass it to the dotnet publish command. This eliminates the need for shell conditionals and makes the Dockerfile simpler and more reliable.

When CI/CD passes a version via build arg, it overrides the default. Otherwise, MinVer uses 0.0.0 as the base version.

[AI-assisted]