### PR TITLE
fix(docker): copy .git directory and pass MinVerVersion to MSBuild closes #281

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 # Git
-.git
+# Note: .git is NOT ignored to allow MinVer to access git metadata during Docker builds
+# This is needed for accurate version calculation using git tags
 .gitignore
 .gitattributes
 

--- a/MediaSet.Api/Dockerfile
+++ b/MediaSet.Api/Dockerfile
@@ -3,11 +3,15 @@ FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
 WORKDIR /src
 
 # Accept version from build args (passed by CI/CD)
+# This will be used by MinVer as a fallback when git directory is not available
 ARG MINVER_VERSION=0.0.0
 
 # Copy global.json and solution file
 COPY global.json ./
 COPY MediaSet.sln ./
+
+# Copy .git directory so MinVer can access git metadata for version calculation
+COPY .git/ .git/
 
 # Copy project file and restore dependencies
 COPY MediaSet.Api/MediaSet.Api.csproj ./MediaSet.Api/
@@ -18,8 +22,7 @@ COPY MediaSet.Api/ ./MediaSet.Api/
 
 # Build and publish
 WORKDIR /src/MediaSet.Api
-ENV MINVER_VERSION=$MINVER_VERSION
-RUN dotnet publish -c Release -o /app/publish --no-restore
+RUN dotnet publish -c Release -o /app/publish --no-restore /p:MinVerVersion=${MINVER_VERSION}
 
 # Runtime stage
 FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS runtime


### PR DESCRIPTION
Configure Docker build process to correctly calculate API version using MinVer:
- Include .git directory in build context by removing it from .dockerignore
- This allows MinVer to access git tags and calculate version from semantic tags
- Pass MINVER_VERSION as MSBuild property /p:MinVerVersion instead of ENV variable
- Add clarifying comments explaining why .git is not ignored

Previously, MinVer would fall back to 0.0.0-alpha.0 because the .git directory was not available in the Docker build context. With .git available, MinVer can correctly read git tags like v1.0.6 and use them for version calculation.

The API /health endpoint will now correctly report the version from git tags and the UI footer will display the correct version instead of 0.0.0-dev.

[AI-assisted]