### PR TITLE
test(ui): Add entity list routes tests

### DIFF
--- a/MediaSet.Remix/app/routes/$entity._index/books.test.tsx
+++ b/MediaSet.Remix/app/routes/$entity._index/books.test.tsx
@@ -1,0 +1,348 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent } from '~/test/test-utils';
+import Books from './books';
+import { BookEntity } from '~/models';
+import { Entity } from '~/models';
+
+// Mock the delete dialog component
+vi.mock('~/components/delete-dialog', () => ({
+  default: ({ isOpen, onClose, entityTitle, deleteAction }: any) => (
+    isOpen ? (
+      <div data-testid="delete-dialog">
+        <p>Delete: {entityTitle}</p>
+        <button onClick={onClose}>Cancel</button>
+        <a href={deleteAction}>Confirm Delete</a>
+      </div>
+    ) : null
+  ),
+}));
+
+// Mock Link to avoid router context requirement
+vi.mock('@remix-run/react', async () => {
+  const actual = await vi.importActual('@remix-run/react');
+  return {
+    ...actual,
+    Link: ({ to, children, ...props }: any) => (
+      <a href={to} {...props}>
+        {children}
+      </a>
+    ),
+  };
+});
+
+describe('Books component', () => {
+  const mockBooks: BookEntity[] = [
+    {
+      type: Entity.Books,
+      id: '1',
+      title: 'The Great Gatsby',
+      authors: ['F. Scott Fitzgerald'],
+      format: 'Hardcover',
+      pages: 180,
+    },
+    {
+      type: Entity.Books,
+      id: '2',
+      title: 'To Kill a Mockingbird',
+      authors: ['Harper Lee'],
+      format: 'Paperback',
+      pages: 324,
+    },
+    {
+      type: Entity.Books,
+      id: '3',
+      title: 'Multiple Authors Book',
+      authors: ['Author One', 'Author Two', 'Author Three'],
+      format: 'eBook',
+      pages: 250,
+    },
+  ];
+
+  describe('rendering', () => {
+    it('should render a table with correct headers and all books', () => {
+      render(<Books books={mockBooks} />);
+
+      expect(screen.getByRole('table')).toBeInTheDocument();
+      expect(screen.getByText('Title')).toBeInTheDocument();
+      expect(screen.getByText('Authors')).toBeInTheDocument();
+      expect(screen.getByText('Format')).toBeInTheDocument();
+      expect(screen.getByText('Pages')).toBeInTheDocument();
+
+      expect(screen.getByText('The Great Gatsby')).toBeInTheDocument();
+      expect(screen.getByText('To Kill a Mockingbird')).toBeInTheDocument();
+      expect(screen.getByText('Multiple Authors Book')).toBeInTheDocument();
+    });
+
+    it('should display book titles as links to detail pages', () => {
+      render(<Books books={mockBooks} />);
+
+      expect(screen.getByText('The Great Gatsby')).toHaveAttribute('href', '/books/1');
+      expect(screen.getByText('To Kill a Mockingbird')).toHaveAttribute('href', '/books/2');
+    });
+
+    it('should display authors and format correctly', () => {
+      render(<Books books={mockBooks} />);
+
+      expect(screen.getByText('F. Scott Fitzgerald')).toBeInTheDocument();
+      expect(screen.getByText('Harper Lee')).toBeInTheDocument();
+      expect(screen.getByText('Hardcover')).toBeInTheDocument();
+      expect(screen.getByText('Paperback')).toBeInTheDocument();
+      expect(screen.getByText('eBook')).toBeInTheDocument();
+    });
+
+    it('should format multiple authors comma-separated', () => {
+      render(<Books books={mockBooks} />);
+
+      expect(screen.getByText('Author One,Author Two,Author Three')).toBeInTheDocument();
+    });
+
+    it('should display page count for each book', () => {
+      render(<Books books={mockBooks} />);
+
+      expect(screen.getByText('180')).toBeInTheDocument();
+      expect(screen.getByText('324')).toBeInTheDocument();
+      expect(screen.getByText('250')).toBeInTheDocument();
+    });
+
+    it('should render edit and delete actions for each book', () => {
+      render(<Books books={mockBooks} />);
+
+      const editLinks = screen.getAllByRole('link', { name: /edit/i });
+      expect(editLinks).toHaveLength(mockBooks.length);
+      expect(editLinks[0]).toHaveAttribute('href', '/books/1/edit');
+      expect(editLinks[1]).toHaveAttribute('href', '/books/2/edit');
+
+      const deleteButtons = screen.getAllByRole('button', { name: /delete/i });
+      expect(deleteButtons).toHaveLength(mockBooks.length);
+    });
+
+    it('should handle book with subtitle', () => {
+      const booksWithSubtitle: BookEntity[] = [
+        {
+          type: Entity.Books,
+          id: '1',
+          title: 'A Book',
+          subtitle: 'The Subtitle',
+          authors: ['Author'],
+        },
+      ];
+
+      render(<Books books={booksWithSubtitle} />);
+
+      expect(screen.getByText('A Book: The Subtitle')).toBeInTheDocument();
+    });
+
+    it('should handle book without subtitle', () => {
+      const booksWithoutSubtitle: BookEntity[] = [
+        {
+          type: Entity.Books,
+          id: '1',
+          title: 'A Book',
+          authors: ['Author'],
+        },
+      ];
+
+      render(<Books books={booksWithoutSubtitle} />);
+
+      expect(screen.getByText('A Book')).toBeInTheDocument();
+    });
+
+    it('should handle empty authors array', () => {
+      const booksNoAuthors: BookEntity[] = [
+        {
+          type: Entity.Books,
+          id: '1',
+          title: 'Anonymous Book',
+          authors: [],
+        },
+      ];
+
+      render(<Books books={booksNoAuthors} />);
+
+      expect(screen.getByText('Anonymous Book')).toBeInTheDocument();
+    });
+
+    it('should handle book with undefined authors', () => {
+      const booksNoAuthors: BookEntity[] = [
+        {
+          type: Entity.Books,
+          id: '1',
+          title: 'Anonymous Book',
+        },
+      ];
+
+      render(<Books books={booksNoAuthors} />);
+
+      expect(screen.getByText('Anonymous Book')).toBeInTheDocument();
+    });
+  });
+
+  describe('delete dialog interactions', () => {
+    it('should not show delete dialog initially', () => {
+      render(<Books books={mockBooks} />);
+
+      expect(screen.queryByTestId('delete-dialog')).not.toBeInTheDocument();
+    });
+
+    it('should show delete dialog when delete button is clicked', () => {
+      render(<Books books={mockBooks} />);
+
+      const firstDeleteButton = screen.getAllByRole('button', { name: /delete/i })[0];
+      fireEvent.click(firstDeleteButton);
+
+      expect(screen.getByTestId('delete-dialog')).toBeInTheDocument();
+      expect(screen.getByText('Delete: The Great Gatsby')).toBeInTheDocument();
+    });
+
+    it('should close delete dialog when cancel is clicked', () => {
+      render(<Books books={mockBooks} />);
+
+      const firstDeleteButton = screen.getAllByRole('button', { name: /delete/i })[0];
+      fireEvent.click(firstDeleteButton);
+
+      expect(screen.getByTestId('delete-dialog')).toBeInTheDocument();
+
+      const cancelButton = screen.getByText('Cancel');
+      fireEvent.click(cancelButton);
+
+      expect(screen.queryByTestId('delete-dialog')).not.toBeInTheDocument();
+    });
+
+    it('should have correct delete action link', () => {
+      render(<Books books={mockBooks} />);
+
+      const firstDeleteButton = screen.getAllByRole('button', { name: /delete/i })[0];
+      fireEvent.click(firstDeleteButton);
+
+      const deleteLink = screen.getByText('Confirm Delete');
+      expect(deleteLink).toHaveAttribute('href', '/books/1/delete');
+    });
+
+    it('should show correct book title in delete dialog for different books', () => {
+      render(<Books books={mockBooks} />);
+
+      const deleteButtons = screen.getAllByRole('button', { name: /delete/i });
+      fireEvent.click(deleteButtons[1]);
+
+      expect(screen.getByText('Delete: To Kill a Mockingbird')).toBeInTheDocument();
+    });
+
+    it('should allow deleting multiple books sequentially', () => {
+      render(<Books books={mockBooks} />);
+
+      const deleteButtons = screen.getAllByRole('button', { name: /delete/i });
+
+      // First delete
+      fireEvent.click(deleteButtons[0]);
+      expect(screen.getByText(/Delete: The Great Gatsby/)).toBeInTheDocument();
+
+      // Cancel first delete
+      fireEvent.click(screen.getByText('Cancel'));
+      expect(screen.queryByTestId('delete-dialog')).not.toBeInTheDocument();
+
+      // Second delete - need to re-query buttons since they may have changed
+      const newDeleteButtons = screen.getAllByRole('button', { name: /delete/i });
+      fireEvent.click(newDeleteButtons[2]); // Third book is now at index 2
+      expect(screen.getByText(/Delete: Multiple Authors Book/)).toBeInTheDocument();
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle empty books array', () => {
+      render(<Books books={[]} />);
+
+      const rows = screen.getAllByRole('row');
+      // Only header row
+      expect(rows).toHaveLength(1);
+    });
+
+    it('should handle single book', () => {
+      const singleBook: BookEntity[] = [mockBooks[0]];
+      render(<Books books={singleBook} />);
+
+      expect(screen.getByText('The Great Gatsby')).toBeInTheDocument();
+      expect(screen.getAllByRole('row')).toHaveLength(2); // header + 1 book
+    });
+
+    it('should handle very long title', () => {
+      const longTitleBook: BookEntity[] = [
+        {
+          type: Entity.Books,
+          id: '1',
+          title: 'This is a very long book title that should still render properly in the table without breaking the layout',
+          authors: ['Author'],
+        },
+      ];
+
+      render(<Books books={longTitleBook} />);
+
+      expect(screen.getByText(/This is a very long book title/)).toBeInTheDocument();
+    });
+
+    it('should trim trailing spaces in author names', () => {
+      const booksWithSpacedAuthors: BookEntity[] = [
+        {
+          type: Entity.Books,
+          id: '1',
+          title: 'Test Book',
+          authors: ['Author One   ', 'Author Two  '],
+        },
+      ];
+
+      render(<Books books={booksWithSpacedAuthors} />);
+
+      expect(screen.getByText('Author One,Author Two')).toBeInTheDocument();
+    });
+  });
+
+  describe('accessibility', () => {
+    it('should have proper aria labels on edit buttons', () => {
+      render(<Books books={mockBooks} />);
+
+      const editButtons = screen.getAllByRole('link', { name: /edit/i });
+      expect(editButtons).toHaveLength(mockBooks.length);
+
+      editButtons.forEach((btn: HTMLElement) => {
+        expect(btn).toHaveAttribute('aria-label', 'Edit');
+      });
+    });
+
+    it('should have proper aria labels on delete buttons', () => {
+      render(<Books books={mockBooks} />);
+
+      const deleteButtons = screen.getAllByRole('button', { name: /delete/i });
+      expect(deleteButtons).toHaveLength(mockBooks.length);
+
+      deleteButtons.forEach((btn: HTMLElement) => {
+        expect(btn).toHaveAttribute('aria-label', 'Delete');
+      });
+    });
+
+    it('should have title attributes for action buttons', () => {
+      render(<Books books={mockBooks} />);
+
+      const editButtons = screen.getAllByRole('link', { name: /edit/i });
+      editButtons.forEach((btn: HTMLElement) => {
+        expect(btn).toHaveAttribute('title', 'Edit');
+      });
+
+      const deleteButtons = screen.getAllByRole('button', { name: /delete/i });
+      deleteButtons.forEach((btn: HTMLElement) => {
+        expect(btn).toHaveAttribute('title', 'Delete');
+      });
+    });
+
+    it('should have proper table structure for screen readers', () => {
+      render(<Books books={mockBooks} />);
+
+      const table = screen.getByRole('table');
+      expect(table).toBeInTheDocument();
+
+      const thead = table.querySelector('thead');
+      expect(thead).toBeInTheDocument();
+
+      const tbody = table.querySelector('tbody');
+      expect(tbody).toBeInTheDocument();
+    });
+  });
+});

--- a/MediaSet.Remix/app/routes/$entity._index/games.test.tsx
+++ b/MediaSet.Remix/app/routes/$entity._index/games.test.tsx
@@ -1,0 +1,403 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent } from '~/test/test-utils';
+import Games from './games';
+import { GameEntity } from '~/models';
+import { Entity } from '~/models';
+
+// Mock the delete dialog component
+vi.mock('~/components/delete-dialog', () => ({
+  default: ({ isOpen, onClose, entityTitle, deleteAction }: any) => (
+    isOpen ? (
+      <div data-testid="delete-dialog">
+        <p>Delete: {entityTitle}</p>
+        <button onClick={onClose}>Cancel</button>
+        <a href={deleteAction}>Confirm Delete</a>
+      </div>
+    ) : null
+  ),
+}));
+
+// Mock Link to avoid router context requirement
+vi.mock('@remix-run/react', async () => {
+  const actual = await vi.importActual('@remix-run/react');
+  return {
+    ...actual,
+    Link: ({ to, children, ...props }: any) => (
+      <a href={to} {...props}>
+        {children}
+      </a>
+    ),
+  };
+});
+
+describe('Games component', () => {
+  const mockGames: GameEntity[] = [
+    {
+      type: Entity.Games,
+      id: '1',
+      title: 'Elden Ring',
+      platform: 'PS5',
+      format: 'Disc',
+      developers: ['FromSoftware'],
+    },
+    {
+      type: Entity.Games,
+      id: '2',
+      title: 'The Legend of Zelda: Breath of the Wild',
+      platform: 'Nintendo Switch',
+      format: 'Physical',
+      developers: ['Nintendo EPD'],
+    },
+    {
+      type: Entity.Games,
+      id: '3',
+      title: 'Baldur\'s Gate 3',
+      platform: 'PC',
+      format: 'Digital',
+      developers: ['Larian Studios'],
+    },
+  ];
+
+  describe('rendering', () => {
+    it('should render a table with correct headers and all games', () => {
+      render(<Games games={mockGames} />);
+
+      expect(screen.getByRole('table')).toBeInTheDocument();
+      expect(screen.getByText('Title')).toBeInTheDocument();
+      expect(screen.getByText('Platform')).toBeInTheDocument();
+      expect(screen.getByText('Format')).toBeInTheDocument();
+      expect(screen.getByText('Developers')).toBeInTheDocument();
+
+      expect(screen.getByText('Elden Ring')).toBeInTheDocument();
+      expect(screen.getByText('The Legend of Zelda: Breath of the Wild')).toBeInTheDocument();
+      expect(screen.getByText('Baldur\'s Gate 3')).toBeInTheDocument();
+    });
+
+    it('should display game titles as links to detail pages', () => {
+      render(<Games games={mockGames} />);
+
+      expect(screen.getByText('Elden Ring')).toHaveAttribute('href', '/games/1');
+      expect(screen.getByText('The Legend of Zelda: Breath of the Wild')).toHaveAttribute('href', '/games/2');
+    });
+
+    it('should display platform, format, and developers', () => {
+      render(<Games games={mockGames} />);
+
+      expect(screen.getByText('PS5')).toBeInTheDocument();
+      expect(screen.getByText('Nintendo Switch')).toBeInTheDocument();
+      expect(screen.getByText('PC')).toBeInTheDocument();
+      expect(screen.getByText('Disc')).toBeInTheDocument();
+      expect(screen.getByText('Physical')).toBeInTheDocument();
+      expect(screen.getByText('Digital')).toBeInTheDocument();
+      expect(screen.getByText('FromSoftware')).toBeInTheDocument();
+      expect(screen.getByText('Nintendo EPD')).toBeInTheDocument();
+      expect(screen.getByText('Larian Studios')).toBeInTheDocument();
+    });
+
+    it('should render edit and delete actions for each game', () => {
+      render(<Games games={mockGames} />);
+
+      const editLinks = screen.getAllByRole('link', { name: /edit/i });
+      expect(editLinks).toHaveLength(mockGames.length);
+      expect(editLinks[0]).toHaveAttribute('href', '/games/1/edit');
+      expect(editLinks[1]).toHaveAttribute('href', '/games/2/edit');
+
+      const deleteButtons = screen.getAllByRole('button', { name: /delete/i });
+      expect(deleteButtons).toHaveLength(mockGames.length);
+    });
+
+    it('should handle game without platform', () => {
+      const gamesNoPlatform: GameEntity[] = [
+        {
+          type: Entity.Games,
+          id: '1',
+          title: 'Test Game',
+          format: 'Disc',
+          developers: ['Dev Studio'],
+        },
+      ];
+
+      render(<Games games={gamesNoPlatform} />);
+
+      expect(screen.getByText('Test Game')).toBeInTheDocument();
+    });
+
+    it('should handle game without developers', () => {
+      const gamesNoDevelopers: GameEntity[] = [
+        {
+          type: Entity.Games,
+          id: '1',
+          title: 'Test Game',
+          platform: 'PS5',
+          format: 'Disc',
+        },
+      ];
+
+      render(<Games games={gamesNoDevelopers} />);
+
+      expect(screen.getByText('Test Game')).toBeInTheDocument();
+    });
+
+    it('should handle game with multiple developers', () => {
+      const gamesMultipleDev: GameEntity[] = [
+        {
+          type: Entity.Games,
+          id: '1',
+          title: 'Test Game',
+          platform: 'PS5',
+          developers: ['Studio A', 'Studio B', 'Studio C'],
+        },
+      ];
+
+      render(<Games games={gamesMultipleDev} />);
+
+      expect(screen.getByText('Studio A, Studio B, Studio C')).toBeInTheDocument();
+    });
+
+    it('should trim trailing spaces in developer names', () => {
+      const gamesSpacedDevelopers: GameEntity[] = [
+        {
+          type: Entity.Games,
+          id: '1',
+          title: 'Test Game',
+          platform: 'PS5',
+          developers: ['Dev Studio  ', 'Another Studio   '],
+        },
+      ];
+
+      render(<Games games={gamesSpacedDevelopers} />);
+
+      expect(screen.getByText('Dev Studio, Another Studio')).toBeInTheDocument();
+    });
+  });
+
+  describe('delete dialog interactions', () => {
+    it('should not show delete dialog initially', () => {
+      render(<Games games={mockGames} />);
+
+      expect(screen.queryByTestId('delete-dialog')).not.toBeInTheDocument();
+    });
+
+    it('should show delete dialog when delete button is clicked', () => {
+      render(<Games games={mockGames} />);
+
+      const firstDeleteButton = screen.getAllByRole('button', { name: /delete/i })[0];
+      fireEvent.click(firstDeleteButton);
+
+      expect(screen.getByTestId('delete-dialog')).toBeInTheDocument();
+      expect(screen.getByText('Delete: Elden Ring')).toBeInTheDocument();
+    });
+
+    it('should close delete dialog when cancel is clicked', () => {
+      render(<Games games={mockGames} />);
+
+      const firstDeleteButton = screen.getAllByRole('button', { name: /delete/i })[0];
+      fireEvent.click(firstDeleteButton);
+
+      expect(screen.getByTestId('delete-dialog')).toBeInTheDocument();
+
+      const cancelButton = screen.getByText('Cancel');
+      fireEvent.click(cancelButton);
+
+      expect(screen.queryByTestId('delete-dialog')).not.toBeInTheDocument();
+    });
+
+    it('should have correct delete action link', () => {
+      render(<Games games={mockGames} />);
+
+      const firstDeleteButton = screen.getAllByRole('button', { name: /delete/i })[0];
+      fireEvent.click(firstDeleteButton);
+
+      const deleteLink = screen.getByText('Confirm Delete');
+      expect(deleteLink).toHaveAttribute('href', '/games/1/delete');
+    });
+
+    it('should show correct game title in delete dialog for different games', () => {
+      render(<Games games={mockGames} />);
+
+      const deleteButtons = screen.getAllByRole('button', { name: /delete/i });
+      fireEvent.click(deleteButtons[2]);
+
+      expect(screen.getByText('Delete: Baldur\'s Gate 3')).toBeInTheDocument();
+    });
+
+    it('should allow deleting multiple games sequentially', () => {
+      render(<Games games={mockGames} />);
+
+      const deleteButtons = screen.getAllByRole('button', { name: /delete/i });
+
+      // First delete
+      fireEvent.click(deleteButtons[0]);
+      expect(screen.getByText(/Delete: Elden Ring/)).toBeInTheDocument();
+
+      // Cancel first delete
+      fireEvent.click(screen.getByText('Cancel'));
+      expect(screen.queryByTestId('delete-dialog')).not.toBeInTheDocument();
+
+      // Second delete - need to re-query buttons
+      const newDeleteButtons = screen.getAllByRole('button', { name: /delete/i });
+      fireEvent.click(newDeleteButtons[2]); // Third game
+      expect(screen.getByText(/Delete: Baldur's Gate 3/)).toBeInTheDocument();
+    });
+  });
+
+  describe('platform variations', () => {
+    it('should handle different platforms', () => {
+      const gameDifferentPlatforms: GameEntity[] = [
+        {
+          type: Entity.Games,
+          id: '1',
+          title: 'Multi-platform Game',
+          platform: 'Xbox Series X',
+          developers: ['Studio'],
+        },
+        {
+          type: Entity.Games,
+          id: '2',
+          title: 'Mobile Game',
+          platform: 'iOS',
+          developers: ['Studio'],
+        },
+        {
+          type: Entity.Games,
+          id: '3',
+          title: 'Indie Game',
+          platform: 'itch.io',
+          developers: ['Studio'],
+        },
+      ];
+
+      render(<Games games={gameDifferentPlatforms} />);
+
+      expect(screen.getByText('Xbox Series X')).toBeInTheDocument();
+      expect(screen.getByText('iOS')).toBeInTheDocument();
+      expect(screen.getByText('itch.io')).toBeInTheDocument();
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle empty games array', () => {
+      render(<Games games={[]} />);
+
+      const rows = screen.getAllByRole('row');
+      // Only header row
+      expect(rows).toHaveLength(1);
+    });
+
+    it('should handle single game', () => {
+      const singleGame: GameEntity[] = [mockGames[0]];
+      render(<Games games={singleGame} />);
+
+      expect(screen.getByText('Elden Ring')).toBeInTheDocument();
+      expect(screen.getAllByRole('row')).toHaveLength(2); // header + 1 game
+    });
+
+    it('should handle very long title', () => {
+      const longTitleGame: GameEntity[] = [
+        {
+          type: Entity.Games,
+          id: '1',
+          title: 'This is a very long game title that should still render properly in the table without breaking the layout',
+          platform: 'PC',
+          developers: ['Dev'],
+        },
+      ];
+
+      render(<Games games={longTitleGame} />);
+
+      expect(screen.getByText(/This is a very long game title/)).toBeInTheDocument();
+    });
+
+    it('should handle many games', () => {
+      const manyGames = Array.from({ length: 50 }, (_, i) => ({
+        type: Entity.Games,
+        id: `game-${i}`,
+        title: `Game ${i}`,
+        platform: `Platform ${i}`,
+        developers: [`Dev ${i}`],
+      }));
+
+      render(<Games games={manyGames} />);
+
+      expect(screen.getByText('Game 0')).toBeInTheDocument();
+      expect(screen.getByText('Game 49')).toBeInTheDocument();
+      const rows = screen.getAllByRole('row');
+      expect(rows).toHaveLength(51); // header + 50 games
+    });
+
+    it('should have unique keys for each row', () => {
+      render(<Games games={mockGames} />);
+
+      const rows = screen.getAllByRole('row');
+      // If we have all rows, keys are properly set
+      expect(rows).toHaveLength(4);
+    });
+
+    it('should handle empty developers array', () => {
+      const gamesEmptyDevelopers: GameEntity[] = [
+        {
+          type: Entity.Games,
+          id: '1',
+          title: 'Unknown Developer Game',
+          platform: 'PS5',
+          developers: [],
+        },
+      ];
+
+      render(<Games games={gamesEmptyDevelopers} />);
+
+      expect(screen.getByText('Unknown Developer Game')).toBeInTheDocument();
+    });
+  });
+
+  describe('accessibility', () => {
+    it('should have proper aria labels on edit buttons', () => {
+      render(<Games games={mockGames} />);
+
+      const editButtons = screen.getAllByRole('link', { name: /edit/i });
+      expect(editButtons).toHaveLength(mockGames.length);
+
+      editButtons.forEach((btn: HTMLElement) => {
+        expect(btn).toHaveAttribute('aria-label', 'Edit');
+      });
+    });
+
+    it('should have proper aria labels on delete buttons', () => {
+      render(<Games games={mockGames} />);
+
+      const deleteButtons = screen.getAllByRole('button', { name: /delete/i });
+      expect(deleteButtons).toHaveLength(mockGames.length);
+
+      deleteButtons.forEach((btn: HTMLElement) => {
+        expect(btn).toHaveAttribute('aria-label', 'Delete');
+      });
+    });
+
+    it('should have title attributes for action buttons', () => {
+      render(<Games games={mockGames} />);
+
+      const editButtons = screen.getAllByRole('link', { name: /edit/i });
+      editButtons.forEach((btn: HTMLElement) => {
+        expect(btn).toHaveAttribute('title', 'Edit');
+      });
+
+      const deleteButtons = screen.getAllByRole('button', { name: /delete/i });
+      deleteButtons.forEach((btn: HTMLElement) => {
+        expect(btn).toHaveAttribute('title', 'Delete');
+      });
+    });
+
+    it('should have proper table structure for screen readers', () => {
+      render(<Games games={mockGames} />);
+
+      const table = screen.getByRole('table');
+      expect(table).toBeInTheDocument();
+
+      const thead = table.querySelector('thead');
+      expect(thead).toBeInTheDocument();
+
+      const tbody = table.querySelector('tbody');
+      expect(tbody).toBeInTheDocument();
+    });
+  });
+});

--- a/MediaSet.Remix/app/routes/$entity._index/movies.test.tsx
+++ b/MediaSet.Remix/app/routes/$entity._index/movies.test.tsx
@@ -1,0 +1,361 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent } from '~/test/test-utils';
+import Movies from './movies';
+import { MovieEntity } from '~/models';
+import { Entity } from '~/models';
+
+// Mock the delete dialog component
+vi.mock('~/components/delete-dialog', () => ({
+  default: ({ isOpen, onClose, entityTitle, deleteAction }: any) => (
+    isOpen ? (
+      <div data-testid="delete-dialog">
+        <p>Delete: {entityTitle}</p>
+        <button onClick={onClose}>Cancel</button>
+        <a href={deleteAction}>Confirm Delete</a>
+      </div>
+    ) : null
+  ),
+}));
+
+// Mock Link to avoid router context requirement
+vi.mock('@remix-run/react', async () => {
+  const actual = await vi.importActual('@remix-run/react');
+  return {
+    ...actual,
+    Link: ({ to, children, ...props }: any) => (
+      <a href={to} {...props}>
+        {children}
+      </a>
+    ),
+  };
+});
+
+describe('Movies component', () => {
+  const mockMovies: MovieEntity[] = [
+    {
+      type: Entity.Movies,
+      id: '1',
+      title: 'The Shawshank Redemption',
+      format: 'Blu-ray',
+      runtime: 142,
+      isTvSeries: false,
+    },
+    {
+      type: Entity.Movies,
+      id: '2',
+      title: 'Breaking Bad',
+      format: 'DVD',
+      runtime: 45,
+      isTvSeries: true,
+    },
+    {
+      type: Entity.Movies,
+      id: '3',
+      title: 'Inception',
+      format: 'Digital',
+      runtime: 148,
+      isTvSeries: false,
+    },
+  ];
+
+  describe('rendering', () => {
+    it('should render a table with correct headers and all movies', () => {
+      render(<Movies movies={mockMovies} />);
+
+      expect(screen.getByRole('table')).toBeInTheDocument();
+      expect(screen.getByText('Title')).toBeInTheDocument();
+      expect(screen.getByText('Format')).toBeInTheDocument();
+      expect(screen.getByText('Runtime')).toBeInTheDocument();
+      expect(screen.getByText('TV Show')).toBeInTheDocument();
+
+      expect(screen.getByText('The Shawshank Redemption')).toBeInTheDocument();
+      expect(screen.getByText('Breaking Bad')).toBeInTheDocument();
+      expect(screen.getByText('Inception')).toBeInTheDocument();
+    });
+
+    it('should display movie titles as links to detail pages', () => {
+      render(<Movies movies={mockMovies} />);
+
+      expect(screen.getByText('The Shawshank Redemption')).toHaveAttribute('href', '/movies/1');
+      expect(screen.getByText('Breaking Bad')).toHaveAttribute('href', '/movies/2');
+    });
+
+    it('should display format and runtime', () => {
+      render(<Movies movies={mockMovies} />);
+
+      expect(screen.getByText('Blu-ray')).toBeInTheDocument();
+      expect(screen.getByText('DVD')).toBeInTheDocument();
+      expect(screen.getByText('Digital')).toBeInTheDocument();
+      expect(screen.getByText('142')).toBeInTheDocument();
+      expect(screen.getByText('45')).toBeInTheDocument();
+      expect(screen.getByText('148')).toBeInTheDocument();
+    });
+
+    it('should render edit and delete actions for each movie', () => {
+      render(<Movies movies={mockMovies} />);
+
+      const editLinks = screen.getAllByRole('link', { name: /edit/i });
+      expect(editLinks).toHaveLength(mockMovies.length);
+      expect(editLinks[0]).toHaveAttribute('href', '/movies/1/edit');
+      expect(editLinks[1]).toHaveAttribute('href', '/movies/2/edit');
+
+      const deleteButtons = screen.getAllByRole('button', { name: /delete/i });
+      expect(deleteButtons).toHaveLength(mockMovies.length);
+    });
+
+    it('should handle movie without runtime', () => {
+      const moviesNoRuntime: MovieEntity[] = [
+        {
+          type: Entity.Movies,
+          id: '1',
+          title: 'Test Movie',
+          format: 'DVD',
+        },
+      ];
+
+      render(<Movies movies={moviesNoRuntime} />);
+
+      expect(screen.getByText('Test Movie')).toBeInTheDocument();
+      expect(screen.getByText('0')).toBeInTheDocument();
+    });
+
+    it('should handle movie without isTvSeries flag', () => {
+      const moviesNoFlag: MovieEntity[] = [
+        {
+          type: Entity.Movies,
+          id: '1',
+          title: 'Test Movie',
+          format: 'DVD',
+          runtime: 120,
+        },
+      ];
+
+      render(<Movies movies={moviesNoFlag} />);
+
+      expect(screen.getByText('Test Movie')).toBeInTheDocument();
+    });
+  });
+
+  describe('TV series vs Movies distinction', () => {
+    it('should distinguish between TV series and movies', () => {
+      render(<Movies movies={mockMovies} />);
+
+      // Breaking Bad (id: 2) is a TV series
+      const breakingBadRow = screen.getByText('Breaking Bad').closest('tr');
+      expect(breakingBadRow).toBeInTheDocument();
+
+      // Inception (id: 3) is not a TV series
+      const inceptionRow = screen.getByText('Inception').closest('tr');
+      expect(inceptionRow).toBeInTheDocument();
+    });
+
+    it('should render all movies correctly regardless of TV series status', () => {
+      const mixedMovies: MovieEntity[] = [
+        {
+          type: Entity.Movies,
+          id: '1',
+          title: 'Movie Only',
+          runtime: 100,
+          isTvSeries: false,
+        },
+        {
+          type: Entity.Movies,
+          id: '2',
+          title: 'TV Series Only',
+          runtime: 45,
+          isTvSeries: true,
+        },
+        {
+          type: Entity.Movies,
+          id: '3',
+          title: 'No Flag',
+          runtime: 120,
+        },
+      ];
+
+      render(<Movies movies={mixedMovies} />);
+
+      expect(screen.getByText('Movie Only')).toBeInTheDocument();
+      expect(screen.getByText('TV Series Only')).toBeInTheDocument();
+      expect(screen.getByText('No Flag')).toBeInTheDocument();
+    });
+  });
+
+  describe('delete dialog interactions', () => {
+    it('should not show delete dialog initially', () => {
+      render(<Movies movies={mockMovies} />);
+
+      expect(screen.queryByTestId('delete-dialog')).not.toBeInTheDocument();
+    });
+
+    it('should show delete dialog when delete button is clicked', () => {
+      render(<Movies movies={mockMovies} />);
+
+      const firstDeleteButton = screen.getAllByRole('button', { name: /delete/i })[0];
+      fireEvent.click(firstDeleteButton);
+
+      expect(screen.getByTestId('delete-dialog')).toBeInTheDocument();
+      expect(screen.getByText('Delete: The Shawshank Redemption')).toBeInTheDocument();
+    });
+
+    it('should close delete dialog when cancel is clicked', () => {
+      render(<Movies movies={mockMovies} />);
+
+      const firstDeleteButton = screen.getAllByRole('button', { name: /delete/i })[0];
+      fireEvent.click(firstDeleteButton);
+
+      expect(screen.getByTestId('delete-dialog')).toBeInTheDocument();
+
+      const cancelButton = screen.getByText('Cancel');
+      fireEvent.click(cancelButton);
+
+      expect(screen.queryByTestId('delete-dialog')).not.toBeInTheDocument();
+    });
+
+    it('should have correct delete action link', () => {
+      render(<Movies movies={mockMovies} />);
+
+      const firstDeleteButton = screen.getAllByRole('button', { name: /delete/i })[0];
+      fireEvent.click(firstDeleteButton);
+
+      const deleteLink = screen.getByText('Confirm Delete');
+      expect(deleteLink).toHaveAttribute('href', '/movies/1/delete');
+    });
+
+    it('should show correct movie title in delete dialog for different movies', () => {
+      render(<Movies movies={mockMovies} />);
+
+      const deleteButtons = screen.getAllByRole('button', { name: /delete/i });
+      fireEvent.click(deleteButtons[1]);
+
+      expect(screen.getByText('Delete: Breaking Bad')).toBeInTheDocument();
+    });
+
+    it('should allow deleting TV series', () => {
+      render(<Movies movies={mockMovies} />);
+
+      const deleteButtons = screen.getAllByRole('button', { name: /delete/i });
+      fireEvent.click(deleteButtons[1]); // Breaking Bad, the TV series
+
+      expect(screen.getByText(/Delete: Breaking Bad/)).toBeInTheDocument();
+      const deleteLink = screen.getByText('Confirm Delete');
+      expect(deleteLink).toHaveAttribute('href', '/movies/2/delete');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle empty movies array', () => {
+      render(<Movies movies={[]} />);
+
+      const rows = screen.getAllByRole('row');
+      // Only header row
+      expect(rows).toHaveLength(1);
+    });
+
+    it('should handle single movie', () => {
+      const singleMovie: MovieEntity[] = [mockMovies[0]];
+      render(<Movies movies={singleMovie} />);
+
+      expect(screen.getByText('The Shawshank Redemption')).toBeInTheDocument();
+      expect(screen.getAllByRole('row')).toHaveLength(2); // header + 1 movie
+    });
+
+    it('should handle very long title', () => {
+      const longTitleMovie: MovieEntity[] = [
+        {
+          type: Entity.Movies,
+          id: '1',
+          title: 'This is a very long movie title that should still render properly in the table without breaking the layout',
+          format: 'DVD',
+          runtime: 120,
+        },
+      ];
+
+      render(<Movies movies={longTitleMovie} />);
+
+      expect(screen.getByText(/This is a very long movie title/)).toBeInTheDocument();
+    });
+
+    it('should handle very large runtime', () => {
+      const longMovies: MovieEntity[] = [
+        {
+          type: Entity.Movies,
+          id: '1',
+          title: 'Long Movie',
+          runtime: 999,
+          isTvSeries: false,
+        },
+      ];
+
+      render(<Movies movies={longMovies} />);
+
+      expect(screen.getByText('999')).toBeInTheDocument();
+    });
+
+    it('should handle zero runtime', () => {
+      const zeroRuntimeMovies: MovieEntity[] = [
+        {
+          type: Entity.Movies,
+          id: '1',
+          title: 'Zero Runtime Movie',
+          runtime: 0,
+        },
+      ];
+
+      render(<Movies movies={zeroRuntimeMovies} />);
+
+      expect(screen.getByText('0')).toBeInTheDocument();
+    });
+  });
+
+  describe('accessibility', () => {
+    it('should have proper aria labels on edit buttons', () => {
+      render(<Movies movies={mockMovies} />);
+
+      const editButtons = screen.getAllByRole('link', { name: /edit/i });
+      expect(editButtons).toHaveLength(mockMovies.length);
+
+      editButtons.forEach((btn: HTMLElement) => {
+        expect(btn).toHaveAttribute('aria-label', 'Edit');
+      });
+    });
+
+    it('should have proper aria labels on delete buttons', () => {
+      render(<Movies movies={mockMovies} />);
+
+      const deleteButtons = screen.getAllByRole('button', { name: /delete/i });
+      expect(deleteButtons).toHaveLength(mockMovies.length);
+
+      deleteButtons.forEach((btn: HTMLElement) => {
+        expect(btn).toHaveAttribute('aria-label', 'Delete');
+      });
+    });
+
+    it('should have title attributes for action buttons', () => {
+      render(<Movies movies={mockMovies} />);
+
+      const editButtons = screen.getAllByRole('link', { name: /edit/i });
+      editButtons.forEach((btn: HTMLElement) => {
+        expect(btn).toHaveAttribute('title', 'Edit');
+      });
+
+      const deleteButtons = screen.getAllByRole('button', { name: /delete/i });
+      deleteButtons.forEach((btn: HTMLElement) => {
+        expect(btn).toHaveAttribute('title', 'Delete');
+      });
+    });
+
+    it('should have proper table structure for screen readers', () => {
+      render(<Movies movies={mockMovies} />);
+
+      const table = screen.getByRole('table');
+      expect(table).toBeInTheDocument();
+
+      const thead = table.querySelector('thead');
+      expect(thead).toBeInTheDocument();
+
+      const tbody = table.querySelector('tbody');
+      expect(tbody).toBeInTheDocument();
+    });
+  });
+});

--- a/MediaSet.Remix/app/routes/$entity._index/musics.test.tsx
+++ b/MediaSet.Remix/app/routes/$entity._index/musics.test.tsx
@@ -1,0 +1,479 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent } from '~/test/test-utils';
+import Musics from './musics';
+import { MusicEntity } from '~/models';
+import { Entity } from '~/models';
+
+// Mock the delete dialog component
+vi.mock('~/components/delete-dialog', () => ({
+  default: ({ isOpen, onClose, entityTitle, deleteAction }: any) => (
+    isOpen ? (
+      <div data-testid="delete-dialog">
+        <p>Delete: {entityTitle}</p>
+        <button onClick={onClose}>Cancel</button>
+        <a href={deleteAction}>Confirm Delete</a>
+      </div>
+    ) : null
+  ),
+}));
+
+// Mock Link to avoid router context requirement
+vi.mock('@remix-run/react', async () => {
+  const actual = await vi.importActual('@remix-run/react');
+  return {
+    ...actual,
+    Link: ({ to, children, ...props }: any) => (
+      <a href={to} {...props}>
+        {children}
+      </a>
+    ),
+  };
+});
+
+describe('Musics component', () => {
+  const mockMusics: MusicEntity[] = [
+    {
+      type: Entity.Musics,
+      id: '1',
+      title: 'Abbey Road',
+      artist: 'The Beatles',
+      format: 'CD',
+      tracks: 17,
+    },
+    {
+      type: Entity.Musics,
+      id: '2',
+      title: 'Dark Side of the Moon',
+      artist: 'Pink Floyd',
+      format: 'Vinyl',
+      tracks: 10,
+    },
+    {
+      type: Entity.Musics,
+      id: '3',
+      title: 'Led Zeppelin IV',
+      artist: 'Led Zeppelin',
+      format: 'CD',
+      tracks: 8,
+    },
+  ];
+
+  describe('rendering', () => {
+    it('should render a table with correct headers and all musics', () => {
+      render(<Musics musics={mockMusics} />);
+
+      expect(screen.getByRole('table')).toBeInTheDocument();
+      expect(screen.getByText('Title')).toBeInTheDocument();
+      expect(screen.getByText('Artist')).toBeInTheDocument();
+      expect(screen.getByText('Format')).toBeInTheDocument();
+      expect(screen.getByText('Tracks')).toBeInTheDocument();
+
+      expect(screen.getByText('Abbey Road')).toBeInTheDocument();
+      expect(screen.getByText('Dark Side of the Moon')).toBeInTheDocument();
+      expect(screen.getByText('Led Zeppelin IV')).toBeInTheDocument();
+    });
+
+    it('should display music titles as links to detail pages', () => {
+      render(<Musics musics={mockMusics} />);
+
+      expect(screen.getByText('Abbey Road')).toHaveAttribute('href', '/musics/1');
+      expect(screen.getByText('Dark Side of the Moon')).toHaveAttribute('href', '/musics/2');
+    });
+
+    it('should display artist, format, and track count', () => {
+      render(<Musics musics={mockMusics} />);
+
+      expect(screen.getByText('The Beatles')).toBeInTheDocument();
+      expect(screen.getByText('Pink Floyd')).toBeInTheDocument();
+      expect(screen.getByText('Led Zeppelin')).toBeInTheDocument();
+      expect(screen.getAllByText('CD')).toBeDefined();
+      expect(screen.getByText('Vinyl')).toBeInTheDocument();
+      expect(screen.getByText('17')).toBeInTheDocument();
+      expect(screen.getByText('10')).toBeInTheDocument();
+      expect(screen.getByText('8')).toBeInTheDocument();
+    });
+
+    it('should render edit and delete actions for each music', () => {
+      render(<Musics musics={mockMusics} />);
+
+      const editLinks = screen.getAllByRole('link', { name: /edit/i });
+      expect(editLinks).toHaveLength(mockMusics.length);
+      expect(editLinks[0]).toHaveAttribute('href', '/musics/1/edit');
+      expect(editLinks[1]).toHaveAttribute('href', '/musics/2/edit');
+
+      const deleteButtons = screen.getAllByRole('button', { name: /delete/i });
+      expect(deleteButtons).toHaveLength(mockMusics.length);
+    });
+
+    it('should handle music without artist', () => {
+      const musicsNoArtist: MusicEntity[] = [
+        {
+          type: Entity.Musics,
+          id: '1',
+          title: 'Unknown Artist Album',
+          format: 'CD',
+          tracks: 12,
+        },
+      ];
+
+      render(<Musics musics={musicsNoArtist} />);
+
+      expect(screen.getByText('Unknown Artist Album')).toBeInTheDocument();
+    });
+
+    it('should handle music without tracks count', () => {
+      const musicsNoTracks: MusicEntity[] = [
+        {
+          type: Entity.Musics,
+          id: '1',
+          title: 'Test Album',
+          artist: 'Test Artist',
+          format: 'CD',
+        },
+      ];
+
+      render(<Musics musics={musicsNoTracks} />);
+
+      expect(screen.getByText('Test Album')).toBeInTheDocument();
+    });
+
+    it('should handle music without format', () => {
+      const musicsNoFormat: MusicEntity[] = [
+        {
+          type: Entity.Musics,
+          id: '1',
+          title: 'Test Album',
+          artist: 'Test Artist',
+          tracks: 12,
+        },
+      ];
+
+      render(<Musics musics={musicsNoFormat} />);
+
+      expect(screen.getByText('Test Album')).toBeInTheDocument();
+    });
+
+    it('should handle different formats', () => {
+      const musicsDifferentFormats: MusicEntity[] = [
+        {
+          type: Entity.Musics,
+          id: '1',
+          title: 'Album 1',
+          artist: 'Artist 1',
+          format: 'CD',
+          tracks: 10,
+        },
+        {
+          type: Entity.Musics,
+          id: '2',
+          title: 'Album 2',
+          artist: 'Artist 2',
+          format: 'Vinyl',
+          tracks: 12,
+        },
+        {
+          type: Entity.Musics,
+          id: '3',
+          title: 'Album 3',
+          artist: 'Artist 3',
+          format: 'Digital',
+          tracks: 15,
+        },
+      ];
+
+      render(<Musics musics={musicsDifferentFormats} />);
+
+      expect(screen.getByText('CD')).toBeInTheDocument();
+      expect(screen.getByText('Vinyl')).toBeInTheDocument();
+      expect(screen.getByText('Digital')).toBeInTheDocument();
+    });
+  });
+
+  describe('delete dialog interactions', () => {
+    it('should not show delete dialog initially', () => {
+      render(<Musics musics={mockMusics} />);
+
+      expect(screen.queryByTestId('delete-dialog')).not.toBeInTheDocument();
+    });
+
+    it('should show delete dialog when delete button is clicked', () => {
+      render(<Musics musics={mockMusics} />);
+
+      const firstDeleteButton = screen.getAllByRole('button', { name: /delete/i })[0];
+      fireEvent.click(firstDeleteButton);
+
+      expect(screen.getByTestId('delete-dialog')).toBeInTheDocument();
+      expect(screen.getByText('Delete: Abbey Road')).toBeInTheDocument();
+    });
+
+    it('should close delete dialog when cancel is clicked', () => {
+      render(<Musics musics={mockMusics} />);
+
+      const firstDeleteButton = screen.getAllByRole('button', { name: /delete/i })[0];
+      fireEvent.click(firstDeleteButton);
+
+      expect(screen.getByTestId('delete-dialog')).toBeInTheDocument();
+
+      const cancelButton = screen.getByText('Cancel');
+      fireEvent.click(cancelButton);
+
+      expect(screen.queryByTestId('delete-dialog')).not.toBeInTheDocument();
+    });
+
+    it('should have correct delete action link', () => {
+      render(<Musics musics={mockMusics} />);
+
+      const firstDeleteButton = screen.getAllByRole('button', { name: /delete/i })[0];
+      fireEvent.click(firstDeleteButton);
+
+      const deleteLink = screen.getByText('Confirm Delete');
+      expect(deleteLink).toHaveAttribute('href', '/musics/1/delete');
+    });
+
+    it('should show correct music title in delete dialog for different musics', () => {
+      render(<Musics musics={mockMusics} />);
+
+      const deleteButtons = screen.getAllByRole('button', { name: /delete/i });
+      fireEvent.click(deleteButtons[1]);
+
+      expect(screen.getByText('Delete: Dark Side of the Moon')).toBeInTheDocument();
+    });
+
+    it('should allow deleting multiple musics sequentially', () => {
+      render(<Musics musics={mockMusics} />);
+
+      const deleteButtons = screen.getAllByRole('button', { name: /delete/i });
+
+      // First delete
+      fireEvent.click(deleteButtons[0]);
+      expect(screen.getByText(/Delete: Abbey Road/)).toBeInTheDocument();
+
+      // Cancel first delete
+      fireEvent.click(screen.getByText('Cancel'));
+      expect(screen.queryByTestId('delete-dialog')).not.toBeInTheDocument();
+
+      // Second delete - need to re-query buttons
+      const newDeleteButtons = screen.getAllByRole('button', { name: /delete/i });
+      fireEvent.click(newDeleteButtons[2]); // Third music
+      expect(screen.getByText(/Delete: Led Zeppelin IV/)).toBeInTheDocument();
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle empty musics array', () => {
+      render(<Musics musics={[]} />);
+
+      const rows = screen.getAllByRole('row');
+      // Only header row
+      expect(rows).toHaveLength(1);
+    });
+
+    it('should handle single music', () => {
+      const singleMusic: MusicEntity[] = [mockMusics[0]];
+      render(<Musics musics={singleMusic} />);
+
+      expect(screen.getByText('Abbey Road')).toBeInTheDocument();
+      expect(screen.getAllByRole('row')).toHaveLength(2); // header + 1 music
+    });
+
+    it('should handle very long title', () => {
+      const longTitleMusic: MusicEntity[] = [
+        {
+          type: Entity.Musics,
+          id: '1',
+          title: 'This is a very long music title that should still render properly in the table without breaking the layout',
+          artist: 'Artist',
+          format: 'CD',
+        },
+      ];
+
+      render(<Musics musics={longTitleMusic} />);
+
+      expect(screen.getByText(/This is a very long music title/)).toBeInTheDocument();
+    });
+
+    it('should handle very long artist name', () => {
+      const longArtistMusic: MusicEntity[] = [
+        {
+          type: Entity.Musics,
+          id: '1',
+          title: 'Album',
+          artist: 'This is a very long artist name that should still render properly',
+          format: 'CD',
+          tracks: 10,
+        },
+      ];
+
+      render(<Musics musics={longArtistMusic} />);
+
+      expect(
+        screen.getByText('This is a very long artist name that should still render properly')
+      ).toBeInTheDocument();
+    });
+
+    it('should handle many musics', () => {
+      const manyMusics = Array.from({ length: 50 }, (_, i) => ({
+        type: Entity.Musics,
+        id: `music-${i}`,
+        title: `Album ${i}`,
+        artist: `Artist ${i}`,
+        format: i % 2 === 0 ? 'CD' : 'Vinyl',
+        tracks: 10 + i,
+      }));
+
+      render(<Musics musics={manyMusics} />);
+
+      expect(screen.getByText('Album 0')).toBeInTheDocument();
+      expect(screen.getByText('Album 49')).toBeInTheDocument();
+      const rows = screen.getAllByRole('row');
+      expect(rows).toHaveLength(51); // header + 50 musics
+    });
+
+    it('should have unique keys for each row', () => {
+      render(<Musics musics={mockMusics} />);
+
+      const rows = screen.getAllByRole('row');
+      // If we have all rows, keys are properly set
+      expect(rows).toHaveLength(4);
+    });
+
+    it('should handle zero tracks', () => {
+      const zeroTracksMusic: MusicEntity[] = [
+        {
+          type: Entity.Musics,
+          id: '1',
+          title: 'Empty Album',
+          artist: 'Artist',
+          format: 'CD',
+          tracks: 0,
+        },
+      ];
+
+      render(<Musics musics={zeroTracksMusic} />);
+
+      expect(screen.getByText('0')).toBeInTheDocument();
+    });
+
+    it('should handle very high track count', () => {
+      const highTrackMusic: MusicEntity[] = [
+        {
+          type: Entity.Musics,
+          id: '1',
+          title: 'Massive Album',
+          artist: 'Artist',
+          format: 'CD',
+          tracks: 999,
+        },
+      ];
+
+      render(<Musics musics={highTrackMusic} />);
+
+      expect(screen.getByText('999')).toBeInTheDocument();
+    });
+  });
+
+  describe('artist display', () => {
+    it('should display single artist correctly', () => {
+      const singleArtistMusic: MusicEntity[] = [
+        {
+          type: Entity.Musics,
+          id: '1',
+          title: 'Album',
+          artist: 'Single Artist',
+          format: 'CD',
+          tracks: 10,
+        },
+      ];
+
+      render(<Musics musics={singleArtistMusic} />);
+
+      expect(screen.getByText('Single Artist')).toBeInTheDocument();
+    });
+
+    it('should display different artists', () => {
+      const multiArtistMusics: MusicEntity[] = [
+        {
+          type: Entity.Musics,
+          id: '1',
+          title: 'Album 1',
+          artist: 'Artist One',
+          format: 'CD',
+          tracks: 10,
+        },
+        {
+          type: Entity.Musics,
+          id: '2',
+          title: 'Album 2',
+          artist: 'Artist Two',
+          format: 'Vinyl',
+          tracks: 12,
+        },
+        {
+          type: Entity.Musics,
+          id: '3',
+          title: 'Album 3',
+          artist: 'Various Artists',
+          format: 'Digital',
+          tracks: 15,
+        },
+      ];
+
+      render(<Musics musics={multiArtistMusics} />);
+
+      expect(screen.getByText('Artist One')).toBeInTheDocument();
+      expect(screen.getByText('Artist Two')).toBeInTheDocument();
+      expect(screen.getByText('Various Artists')).toBeInTheDocument();
+    });
+  });
+
+  describe('accessibility', () => {
+    it('should have proper aria labels on edit buttons', () => {
+      render(<Musics musics={mockMusics} />);
+
+      const editButtons = screen.getAllByRole('link', { name: /edit/i });
+      expect(editButtons).toHaveLength(mockMusics.length);
+
+      editButtons.forEach((btn: HTMLElement) => {
+        expect(btn).toHaveAttribute('aria-label', 'Edit');
+      });
+    });
+
+    it('should have proper aria labels on delete buttons', () => {
+      render(<Musics musics={mockMusics} />);
+
+      const deleteButtons = screen.getAllByRole('button', { name: /delete/i });
+      expect(deleteButtons).toHaveLength(mockMusics.length);
+
+      deleteButtons.forEach((btn: HTMLElement) => {
+        expect(btn).toHaveAttribute('aria-label', 'Delete');
+      });
+    });
+
+    it('should have title attributes for action buttons', () => {
+      render(<Musics musics={mockMusics} />);
+
+      const editButtons = screen.getAllByRole('link', { name: /edit/i });
+      editButtons.forEach((btn: HTMLElement) => {
+        expect(btn).toHaveAttribute('title', 'Edit');
+      });
+
+      const deleteButtons = screen.getAllByRole('button', { name: /delete/i });
+      deleteButtons.forEach((btn: HTMLElement) => {
+        expect(btn).toHaveAttribute('title', 'Delete');
+      });
+    });
+
+    it('should have proper table structure for screen readers', () => {
+      render(<Musics musics={mockMusics} />);
+
+      const table = screen.getByRole('table');
+      expect(table).toBeInTheDocument();
+
+      const thead = table.querySelector('thead');
+      expect(thead).toBeInTheDocument();
+
+      const tbody = table.querySelector('tbody');
+      expect(tbody).toBeInTheDocument();
+    });
+  });
+});

--- a/MediaSet.Remix/app/routes/$entity._index/route.test.tsx
+++ b/MediaSet.Remix/app/routes/$entity._index/route.test.tsx
@@ -1,0 +1,239 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { meta, loader } from './route';
+import * as entityData from '~/entity-data';
+import * as helpers from '~/helpers';
+import { Entity, BookEntity, MovieEntity, GameEntity, MusicEntity } from '~/models';
+
+// Mock modules
+vi.mock('~/entity-data');
+vi.mock('~/helpers');
+
+const mockSearchEntities = vi.mocked(entityData.searchEntities);
+const mockGetEntityFromParams = vi.mocked(helpers.getEntityFromParams);
+
+describe('$entity._index route', () => {
+  describe('meta function', () => {
+    it('should return correct title and description for Books', () => {
+      mockGetEntityFromParams.mockReturnValue(Entity.Books);
+      const result = meta({ params: { entity: 'books' } } as any);
+      expect(result).toContainEqual(
+        expect.objectContaining({ title: expect.stringContaining('List') })
+      );
+      expect(result).toContainEqual(
+        expect.objectContaining({ name: 'description' })
+      );
+    });
+
+    it('should return correct title and description for Movies', () => {
+      mockGetEntityFromParams.mockReturnValue(Entity.Movies);
+      const result = meta({ params: { entity: 'movies' } } as any);
+      expect(result).toContainEqual(
+        expect.objectContaining({ title: expect.stringContaining('List') })
+      );
+    });
+
+    it('should return correct title and description for Games', () => {
+      mockGetEntityFromParams.mockReturnValue(Entity.Games);
+      const result = meta({ params: { entity: 'games' } } as any);
+      expect(result).toContainEqual(
+        expect.objectContaining({ title: expect.stringContaining('List') })
+      );
+    });
+
+    it('should return correct title and description for Musics', () => {
+      mockGetEntityFromParams.mockReturnValue(Entity.Musics);
+      const result = meta({ params: { entity: 'musics' } } as any);
+      expect(result).toContainEqual(
+        expect.objectContaining({ title: expect.stringContaining('List') })
+      );
+    });
+
+    it('should have 2 meta tags', () => {
+      mockGetEntityFromParams.mockReturnValue(Entity.Books);
+      const result = meta({ params: { entity: 'books' } } as any);
+      expect(result).toHaveLength(2);
+    });
+  });
+
+  describe('loader function', () => {
+    beforeEach(() => {
+      vi.clearAllMocks();
+    });
+
+    it('should load books with search text', async () => {
+      const mockBooks: BookEntity[] = [
+        {
+          type: Entity.Books,
+          id: '1',
+          title: 'Test Book',
+          authors: ['Author One'],
+        },
+      ];
+
+      mockGetEntityFromParams.mockReturnValue(Entity.Books);
+      mockSearchEntities.mockResolvedValue(mockBooks);
+
+      const mockRequest = new Request('http://localhost/books?searchText=test');
+      const result = await loader({
+        request: mockRequest,
+        params: { entity: 'books' },
+      } as any);
+
+      expect(mockSearchEntities).toHaveBeenCalledWith(Entity.Books, 'test');
+      expect(result).toEqual({ entities: mockBooks, entityType: Entity.Books });
+    });
+
+    it('should load movies without search text', async () => {
+      const mockMovies: MovieEntity[] = [
+        {
+          type: Entity.Movies,
+          id: '1',
+          title: 'Test Movie',
+        },
+      ];
+
+      mockGetEntityFromParams.mockReturnValue(Entity.Movies);
+      mockSearchEntities.mockResolvedValue(mockMovies);
+
+      const mockRequest = new Request('http://localhost/movies');
+      const result = await loader({
+        request: mockRequest,
+        params: { entity: 'movies' },
+      } as any);
+
+      expect(mockSearchEntities).toHaveBeenCalledWith(Entity.Movies, null);
+      expect(result).toEqual({ entities: mockMovies, entityType: Entity.Movies });
+    });
+
+    it('should load games with search text', async () => {
+      const mockGames: GameEntity[] = [
+        {
+          type: Entity.Games,
+          id: '1',
+          title: 'Test Game',
+          platform: 'PS5',
+        },
+      ];
+
+      mockGetEntityFromParams.mockReturnValue(Entity.Games);
+      mockSearchEntities.mockResolvedValue(mockGames);
+
+      const mockRequest = new Request('http://localhost/games?searchText=action');
+      const result = await loader({
+        request: mockRequest,
+        params: { entity: 'games' },
+      } as any);
+
+      expect(mockSearchEntities).toHaveBeenCalledWith(Entity.Games, 'action');
+      expect(result).toEqual({ entities: mockGames, entityType: Entity.Games });
+    });
+
+    it('should load musics with search text', async () => {
+      const mockMusics: MusicEntity[] = [
+        {
+          type: Entity.Musics,
+          id: '1',
+          title: 'Test Album',
+          artist: 'Test Artist',
+        },
+      ];
+
+      mockGetEntityFromParams.mockReturnValue(Entity.Musics);
+      mockSearchEntities.mockResolvedValue(mockMusics);
+
+      const mockRequest = new Request('http://localhost/musics?searchText=rock');
+      const result = await loader({
+        request: mockRequest,
+        params: { entity: 'musics' },
+      } as any);
+
+      expect(mockSearchEntities).toHaveBeenCalledWith(Entity.Musics, 'rock');
+      expect(result).toEqual({ entities: mockMusics, entityType: Entity.Musics });
+    });
+
+    it('should handle empty search results', async () => {
+      mockGetEntityFromParams.mockReturnValue(Entity.Books);
+      mockSearchEntities.mockResolvedValue([]);
+
+      const mockRequest = new Request('http://localhost/books?searchText=nonexistent');
+      const result = await loader({
+        request: mockRequest,
+        params: { entity: 'books' },
+      } as any);
+
+      expect(result).toEqual({ entities: [], entityType: Entity.Books });
+    });
+
+    it('should throw error if entity param is missing', async () => {
+      const mockRequest = new Request('http://localhost/test');
+      
+      await expect(
+        loader({
+          request: mockRequest,
+          params: {},
+        } as any)
+      ).rejects.toThrow();
+    });
+
+    it('should handle multiple results from search', async () => {
+      const mockBooks: BookEntity[] = [
+        { type: Entity.Books, id: '1', title: 'Book 1', authors: ['Author 1'] },
+        { type: Entity.Books, id: '2', title: 'Book 2', authors: ['Author 2'] },
+        { type: Entity.Books, id: '3', title: 'Book 3', authors: ['Author 3'] },
+      ];
+
+      mockGetEntityFromParams.mockReturnValue(Entity.Books);
+      mockSearchEntities.mockResolvedValue(mockBooks);
+
+      const mockRequest = new Request('http://localhost/books?searchText=book');
+      const result = await loader({
+        request: mockRequest,
+        params: { entity: 'books' },
+      } as any);
+
+      expect(result.entities).toHaveLength(3);
+      expect(result.entities).toEqual(mockBooks);
+    });
+
+    it('should pass correct entity type to searchEntities', async () => {
+      mockGetEntityFromParams.mockReturnValue(Entity.Games);
+      mockSearchEntities.mockResolvedValue([]);
+
+      const mockRequest = new Request('http://localhost/games?searchText=zelda');
+      await loader({
+        request: mockRequest,
+        params: { entity: 'games' },
+      } as any);
+
+      expect(mockGetEntityFromParams).toHaveBeenCalledWith({ entity: 'games' });
+      expect(mockSearchEntities).toHaveBeenCalledWith(Entity.Games, 'zelda');
+    });
+
+    it('should extract search text from URL query parameters', async () => {
+      mockGetEntityFromParams.mockReturnValue(Entity.Books);
+      mockSearchEntities.mockResolvedValue([]);
+
+      const mockRequest = new Request('http://localhost/books?searchText=multiple%20words');
+      await loader({
+        request: mockRequest,
+        params: { entity: 'books' },
+      } as any);
+
+      expect(mockSearchEntities).toHaveBeenCalledWith(Entity.Books, 'multiple words');
+    });
+
+    it('should handle null search text when not provided', async () => {
+      mockGetEntityFromParams.mockReturnValue(Entity.Movies);
+      mockSearchEntities.mockResolvedValue([]);
+
+      const mockRequest = new Request('http://localhost/movies');
+      await loader({
+        request: mockRequest,
+        params: { entity: 'movies' },
+      } as any);
+
+      expect(mockSearchEntities).toHaveBeenCalledWith(Entity.Movies, null);
+    });
+  });
+});
+

--- a/MediaSet.Remix/app/test/test-utils.tsx
+++ b/MediaSet.Remix/app/test/test-utils.tsx
@@ -17,3 +17,6 @@ function customRender(
 // Re-export everything from @testing-library/react
 export * from '@testing-library/react';
 export { customRender as render };
+
+// Explicitly re-export commonly used utilities for convenience
+export { screen, fireEvent } from '@testing-library/react';


### PR DESCRIPTION
Add comprehensive test coverage for entity list page rendering, data loading, filtering, and interactions. Tests cover all entity types (books, movies, games, music) with focus on:

- Route loader and meta function behavior
- Entity rendering and data display
- Search text parameter handling
- Empty state rendering
- Navigation and action links
- Delete dialog interactions
- Accessibility (aria labels, semantic structure)

Achieves 74.41% coverage for entity list routes and 94.38% overall coverage, exceeding the 70% target.

Closes #317