### PR TITLE
chore(docs): consolidate and reorganize copilot instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -11,8 +11,7 @@ MediaSet is a full-stack application for managing personal media collections. Th
 
 ### Branch Protection
 - **NEVER commit to `main`**
-- Always create a feature branch from updated `main`: `git checkout -b feature/description` or `fix/description`
-- Push branches and open Pull Requests for code review
+- Always create a feature branch: `git checkout -b feature/description` or `fix/description`
 
 ### Commit Requirements
 - Follow Conventional Commits: `type(scope): description`
@@ -22,23 +21,72 @@ MediaSet is a full-stack application for managing personal media collections. Th
 - Reference issues: use `closes #N` for final commits, `refs #N` for intermediate commits
 - Add additional context in the body if needed
 - Add `[AI-assisted]` tag or `Co-authored-by: GitHub Copilot <copilot@github.com>` trailer
-- Always verify changes with user before committing
 
-## Project Overview
+### Agent Workflow
+- **Propose changes first**: Show the user the planned changes before implementation
+- **Wait for approval**: Confirm the user approves the approach
+- **Create and commit**: Only create commits once the user confirms the changes are correct
+- **Push to feature branch**: Agent pushes to the feature branch only
+- **User responsibility**: User creates PR and handles merge to `main`
 
-MediaSet is a full-stack application managing personal media collections.
+## Naming Conventions
 
-- Backend: .NET 9.0 Web API with MongoDB
-- Frontend: Remix.js with TypeScript and Tailwind CSS
+| Type | Convention | Example |
+|------|-----------|---------|
+| Classes/Components | PascalCase | `BookController`, `MovieCard` |
+| Functions/Variables | camelCase | `fetchBooks`, `formatTitle` |
+| Constants | SCREAMING_SNAKE_CASE | `MAX_ITEMS`, `DEFAULT_SORT` |
+| Interfaces | PascalCase | `IBook`, `MovieCardProps` |
 
-## Common Development Tasks
+## Code Quality
 
-1. **Add Entity Properties**: Update model → TypeScript interface → form component
-2. **Add API Endpoints**: Add controller route → data function in frontend
-3. **Add UI Features**: Create components → update routes
+- Use meaningful variable and function names that clearly indicate purpose
+- Keep functions small and focused on a single responsibility
+- Add comments only for complex logic, not obvious code
+- Remove unused imports, variables, and code
+- Remove outdated comments
+- Use const/final for values that don't change, let/var for values that do
+
+## Type Safety
+
+- Always use TypeScript/C# type annotations
+- Avoid `any` type in TypeScript; prefer `unknown` if type is truly unknown
+- Define interfaces for all data structures
+- Use union types and type guards where appropriate
+- Prefer specific types over generic types
+
+## Testing Practices
+
+- Follow AAA pattern: **Arrange** (setup), **Act** (execute), **Assert** (verify)
+- Test edge cases and error scenarios
+- Keep tests focused and single-purpose
+- Write test names that describe behavior clearly
+- Always include test updates with code changes
 
 ## Development Commands
 
 ```bash
-./dev.sh start # Start backend API and frontend UI and MongoDB
+# Start entire development environment
+./dev.sh start
+
+# Start specific components
+./dev.sh start api           # Start backend API only
+./dev.sh start frontend      # Start frontend UI only
+
+# Restart components
+./dev.sh restart api         # Restart backend API
+./dev.sh restart frontend    # Restart frontend UI
+
+# Stop components
+./dev.sh stop api            # Stop backend API
+./dev.sh stop frontend       # Stop frontend UI
+
+# Backend tests
+dotnet test MediaSet.Api.Tests/MediaSet.Api.Tests.csproj
+
+# Frontend tests
+cd MediaSet.Remix && npm test
+
+# Frontend build
+cd MediaSet.Remix && npm run build
 ```

--- a/.github/instructions/backend.instructions.md
+++ b/.github/instructions/backend.instructions.md
@@ -13,10 +13,11 @@ applyTo: "**/*.cs"
 
 ## Naming Conventions
 
-- **Public**: PascalCase (properties, methods, classes)
-- **Private**: camelCase for fields and parameters
-- **Injected dependencies**: Prefix underscore (e.g., `_httpClient`, `_logger`)
-- **Collections**: Use plural names (e.g., `Authors`, `Genres`, `Studios`)
+- **Files**: PascalCase | `BookController.cs`, `MovieEntity.cs`
+- **Public members**: PascalCase (properties, methods, classes)
+- **Private members**: camelCase for fields and parameters
+- **Injected dependencies**: `_camelCase` prefix | `_httpClient`, `_logger`
+- **Collections**: plural names | `Authors`, `Genres`, `Studios`
 
 ## Code Style
 
@@ -66,26 +67,13 @@ applyTo: "**/*.cs"
 ## Error Handling
 
 - Return appropriate HTTP status codes using TypedResults
-- Log errors with sufficient context for debugging
 - Validate input parameters and return BadRequest for invalid data
+- Log errors with sufficient context for debugging
 - Use pattern matching for result handling where appropriate
 
 ## Testing
 
 - Use NUnit for unit tests
+- Test naming: `MethodName_Scenario_ExpectedResult`
 - Consider in-memory MongoDB for integration tests
-- Follow AAA pattern (Arrange, Act, Assert)
-- Name tests: `MethodName_Scenario_ExpectedResult`
-- Always include test updates with code changes
-
-## Development Commands
-
-```bash
-./dev.sh start api # Start backend API
-
-./dev.sh restart api # Restart backend API
-
-./dev.sh stop api # Stop backend API
-
-dotnet test MediaSet.Api.Tests/MediaSet.Api.Tests.csproj # Run backend tests
-```
+- Mock external dependencies appropriately

--- a/.github/instructions/frontend.instructions.md
+++ b/.github/instructions/frontend.instructions.md
@@ -14,6 +14,14 @@ applyTo: "**/*.ts,**/*.tsx"
 - Place type definitions in `app/models.ts` or co-locate with components
 - Use `.tsx` for files with JSX, `.ts` for pure TypeScript
 
+## Naming Conventions
+
+- **Components**: PascalCase class in `kebab-case.tsx` file | `MovieCard` class in `movie-card.tsx`
+- **Functions/variables**: camelCase | `fetchBooks`, `formatTitle`
+- **Interfaces**: PascalCase (optionally `IPascalCase` prefix) | `IBook`, `MovieCardProps`
+- **Constants**: SCREAMING_SNAKE_CASE | `MAX_ITEMS`, `DEFAULT_SORT`
+- **Files**: `kebab-case.ts` or `kebab-case.tsx` | `movie-card.tsx`, `data-functions.ts`
+
 ## TypeScript
 
 - Always use TypeScript for type safety
@@ -21,14 +29,6 @@ applyTo: "**/*.ts,**/*.tsx"
 - Use type annotations for function parameters and return types
 - Avoid `any` type; prefer `unknown` if type is truly unknown
 - Use union types and type guards where appropriate
-
-## Naming Conventions
-
-- **Components**: PascalCase (e.g., `BookList.tsx`, `MovieCard.tsx`)
-- **Functions/variables**: camelCase (e.g., `fetchBooks`, `formatTitle`)
-- **Interfaces**: PascalCase (e.g., `IBook`, `MovieCardProps`)
-- **Constants**: SCREAMING_SNAKE_CASE (e.g., `MAX_ITEMS`, `DEFAULT_SORT`)
-- Use descriptive names that clearly indicate purpose
 
 ## Component Design
 
@@ -57,22 +57,6 @@ applyTo: "**/*.ts,**/*.tsx"
 - Follow mobile-first responsive design approach
 - Utilize global styles in `app/tailwind.css` for common styles
 
-## Code Quality
-
-- Use meaningful variable and function names
-- Keep functions small and focused
-- Add comments only for complex logic, not obvious code
-- Remove unused imports, variables, and code
-- Remove outdated comments
-- Use `const` for values that don't change, `let` for values that do
-
-## Error Handling
-
-- Handle errors gracefully with user-friendly messages
-- Use Remix's error boundaries for route-level errors
-- Validate form inputs on both client and server
-- Provide loading states for async operations
-
 ## Accessibility
 
 - Use semantic HTML elements
@@ -81,21 +65,24 @@ applyTo: "**/*.ts,**/*.tsx"
 - Maintain sufficient color contrast
 - Test with screen readers when possible
 
+## Error Handling
+
+- Handle errors gracefully with user-friendly messages
+- Use error boundaries for component-level error handling
+- Validate form inputs on both client and server
+- Provide loading states for async operations
+- Use Remix error boundaries for route-level errors
+
+## Logging
+
+- Log errors with sufficient context for debugging
+- Use console methods appropriately (console.error for errors, console.info for important info)
+- Avoid verbose logging in production
+
 ## Testing
 
 - Use Vitest for unit tests
 - Use React Testing Library for component tests
-- Test user interactions and edge cases
+- Test naming: `should [expected behavior] when [condition]`
+- Test user interactions over implementation details
 - Mock external dependencies appropriately
-- Name tests: `should [expected behavior] when [condition]`
-- Always include test updates with code changes
-
-## Development Commands
-
-```bash
-cd MediaSet.Remix && npm run build # Frontend build
-
-cd MediaSet.Remix && npm test # Frontend tests
-
-./dev.sh start frontend # Start frontend UI
-```


### PR DESCRIPTION
- Moved language-specific naming conventions to respective files:
  - backend.instructions.md: C#-specific naming
  - frontend.instructions.md: TypeScript-specific naming
- Moved language-specific testing practices:
  - backend.instructions.md: NUnit test guidance
  - frontend.instructions.md: Vitest/RTL test guidance
- Moved error handling and logging to language-specific files
- Renamed instruction files for clarity:
  - dotnet.instructions.md → backend.instructions.md
  - ui.instructions.md → frontend.instructions.md
- Removed redundant 'Common Development Tasks' and 'Code Organization Principles'
- Cleaned up Branch Protection and Agent Workflow sections
- Each instruction file is now self-contained for its domain
- Reduced redundancy by consolidating related guidance

Result: copilot-instructions.md now contains only universal guidance [AI-assisted]