### PR TITLE
fix(ui): centralize page-level spinner for all form operations closes #297

### DIFF
--- a/MediaSet.Remix/app/components/pending-navigation.test.tsx
+++ b/MediaSet.Remix/app/components/pending-navigation.test.tsx
@@ -52,14 +52,14 @@ describe('PendingNavigation', () => {
       expect(container.firstChild).not.toBeNull();
     });
 
-    it('should not render when navigation state is submitting', () => {
+    it('should render when navigation state is submitting', () => {
       vi.mocked(useNavigation).mockReturnValue({
         state: 'submitting',
       } as any);
 
       const { container } = render(<PendingNavigation />);
 
-      expect(container.firstChild).toBeNull();
+      expect(container.firstChild).not.toBeNull();
     });
 
     it('should handle state transitions from idle to loading', async () => {
@@ -478,8 +478,9 @@ describe('PendingNavigation', () => {
 
       const { container } = render(<PendingNavigation />);
 
-      // Should not show spinner during submission
-      expect(container.firstChild).toBeNull();
+      // Should show spinner during submission
+      expect(container.firstChild).not.toBeNull();
+      expect(screen.queryByTestId('spinner')).toBeInTheDocument();
     });
 
     it('should work with multiple PendingNavigation components', () => {

--- a/MediaSet.Remix/app/components/pending-navigation.tsx
+++ b/MediaSet.Remix/app/components/pending-navigation.tsx
@@ -15,5 +15,5 @@ export default function PendingNavigation() {
     </>
   );
 
-  return navigation.state === "loading" ? spinner : null;
+  return navigation.state === "loading" || navigation.state === "submitting" ? spinner : null;
 }

--- a/MediaSet.Remix/app/routes/$entity_.$entityId_.edit/route.test.tsx
+++ b/MediaSet.Remix/app/routes/$entity_.$entityId_.edit/route.test.tsx
@@ -626,17 +626,6 @@ describe('$entity_.$entityId_.edit route', () => {
       expect(hiddenInput).toHaveAttribute('name', 'type');
     });
 
-    it('should show spinner when submitting', () => {
-      mockUseNavigation.mockReturnValue({
-        state: 'submitting',
-        location: { pathname: '/books/book-1/edit' },
-      } as any);
-
-      render(<Edit />);
-
-      expect(screen.getByTestId('spinner')).toBeInTheDocument();
-    });
-
     it('should disable buttons when submitting', () => {
       mockUseNavigation.mockReturnValue({
         state: 'submitting',

--- a/MediaSet.Remix/app/routes/$entity_.$entityId_.edit/route.tsx
+++ b/MediaSet.Remix/app/routes/$entity_.$entityId_.edit/route.tsx
@@ -1,7 +1,6 @@
 import type { MetaFunction, ActionFunctionArgs, LoaderFunctionArgs } from "@remix-run/node";
 import { Form, redirect, useActionData, useLoaderData, useNavigate, useNavigation } from "@remix-run/react";
 import { addEntity, getEntity, updateEntity } from "~/entity-data";
-import Spinner from "~/components/spinner";
 import { getAuthors, getFormats, getGenres, getPublishers, getStudios, getDevelopers, getLabels, getGamePublishers, getPlatforms } from "~/metadata-data";
 import { formToDto, getEntityFromParams, singular } from "~/helpers";
 import { BookEntity, Entity, GameEntity, MovieEntity, MusicEntity } from "~/models";
@@ -109,8 +108,7 @@ export default function Edit() {
               )}
               {formComponent}
               <div className="flex flex-row gap-2 mt-3">
-                <button type="submit" className="flex flex-row gap-2" disabled={isSubmitting}>
-                  {isSubmitting ? <div className="flex items-center"><Spinner /></div> : null}
+                <button type="submit" disabled={isSubmitting}>
                   Update
                 </button>
                 <button type="button" onClick={() => navigate(-1)} className="secondary" disabled={isSubmitting}>Cancel</button>

--- a/MediaSet.Remix/app/routes/$entity_.add/route.test.tsx
+++ b/MediaSet.Remix/app/routes/$entity_.add/route.test.tsx
@@ -598,14 +598,6 @@ describe('$entity_.add route', () => {
       expect(screen.getByTestId('book-form')).toBeInTheDocument();
     });
 
-    it('should show spinner when submitting', () => {
-      mockUseNavigation.mockReturnValue({ state: 'submitting' } as any);
-
-      render(<Add />);
-
-      expect(screen.getByTestId('spinner')).toBeInTheDocument();
-    });
-
     it('should disable buttons when submitting', () => {
       mockUseNavigation.mockReturnValue({ state: 'submitting' } as any);
 

--- a/MediaSet.Remix/app/routes/$entity_.add/route.tsx
+++ b/MediaSet.Remix/app/routes/$entity_.add/route.tsx
@@ -3,7 +3,6 @@ import { Form, redirect, useActionData, useLoaderData, useNavigate, useNavigatio
 import { useEffect, useRef } from "react";
 import invariant from "tiny-invariant";
 import { addEntity } from "~/entity-data";
-import Spinner from "~/components/spinner";
 import { getAuthors, getFormats, getGenres, getPublishers, getStudios, getDevelopers, getLabels, getGamePublishers, getPlatforms } from "~/metadata-data";
 import { formToDto, getEntityFromParams, singular } from "~/helpers";
 import { BookEntity, Entity, GameEntity, MusicEntity, MovieEntity } from "~/models";
@@ -133,7 +132,6 @@ export default function Add() {
                 className="flex flex-row gap-2" 
                 disabled={isSubmitting}
               >
-                {isSubmitting && <div className="flex items-center"><Spinner /></div>}
                 Add {singular(entityType)}
               </button>
               <button 


### PR DESCRIPTION
- Update PendingNavigation to show spinner for both 'loading' and 'submitting' states
- Remove duplicate spinner logic from add and edit routes
- Update tests to reflect centralized spinner handling
- Spinner now displays uniformly for add, edit, and lookup operations

[AI-assisted]