### PR TITLE
fix(ui): fix mouse selection in dropdown inputs closes #352

### DIFF
--- a/MediaSet.Remix/app/components/multiselect-input.tsx
+++ b/MediaSet.Remix/app/components/multiselect-input.tsx
@@ -162,7 +162,7 @@ export default function MultiselectInput(props: MultiselectProps) {
       {/* click-away overlay */}
       <div
         className={`absolute top-0 left-0 z-10 w-full h-full ${displayOptions ? "" : "hidden"}`}
-        onClick={() => setDisplayOptions(false)}
+        onMouseDown={() => setDisplayOptions(false)}
       ></div>
 
       <div className="flex flex-col gap-2">
@@ -226,7 +226,8 @@ export default function MultiselectInput(props: MultiselectProps) {
                 role="option"
                 aria-selected={selectedFlag}
                 onMouseEnter={() => setActiveIndex(idx)}
-                onClick={() => {
+                onMouseDown={(e) => {
+                  e.preventDefault();
                   toggleSelected(option);
                   // Keep menu open for multiple selections; refocus input for continued typing
                   inputRef.current?.focus();

--- a/MediaSet.Remix/app/components/singleselect-input.tsx
+++ b/MediaSet.Remix/app/components/singleselect-input.tsx
@@ -158,7 +158,7 @@ export default function SingleselectInput(props: SingleselectProps) {
       {/* click-away overlay */}
       <div
         className={`absolute top-0 left-0 z-10 w-full h-full ${displayOptions ? "" : "hidden"}`}
-        onClick={() => setDisplayOptions(false)}
+        onMouseDown={() => setDisplayOptions(false)}
       ></div>
 
       <div className="flex flex-col">
@@ -212,7 +212,8 @@ export default function SingleselectInput(props: SingleselectProps) {
                 role="option"
                 aria-selected={activeFlag}
                 onMouseEnter={() => setActiveIndex(idx)}
-                onClick={() => {
+                onMouseDown={(e) => {
+                  e.preventDefault();
                   selectOption(option);
                 }}
                 className={`px-3 py-2 text-white cursor-pointer hover:bg-gray-600 ${


### PR DESCRIPTION
Changed event handlers from onClick to onMouseDown with preventDefault in both SingleselectInput and MultiselectInput components. This prevents the input blur event from interfering with option selection when clicking with the mouse.

The blur event was firing before the click handler could complete, causing the dropdown to close before registering the selection. Using onMouseDown with preventDefault ensures the selection happens before any blur event can interfere.

[AI-assisted]