### PR TITLE
fix(api,ui): resolve image editing and deletion bugs

### DIFF
--- a/MediaSet.Api/Entities/EntityApi.cs
+++ b/MediaSet.Api/Entities/EntityApi.cs
@@ -245,6 +245,16 @@ internal static class EntityApi
                         }
                     }
                 }
+                else
+                {
+                    // For JSON requests, check if image is being cleared (updatedEntity.CoverImage is null but existing had one)
+                    if (updatedEntity.CoverImage is null && existingEntity.CoverImage is not null)
+                    {
+                        logger.LogInformation("Image is being cleared for {entityType}/{id}", entityType, id);
+                        // Pass existingEntity so DeleteOldImage can access the CoverImage data to delete
+                        DeleteOldImage(existingEntity, imageService, logger);
+                    }
+                }
 
                 var result = await entityService.UpdateAsync(id, updatedEntity, cancellationToken);
                 logger.LogInformation("Updated {entityType} {entityId}: {updated}", entityType, id, result.ModifiedCount > 0);

--- a/MediaSet.Remix/app/components/image-upload.test.tsx
+++ b/MediaSet.Remix/app/components/image-upload.test.tsx
@@ -206,9 +206,9 @@ describe("ImageUpload Component", () => {
     it("should display existing image preview", () => {
       const existingImage: ImageData = {
         fileName: "existing.jpg",
-        mimeType: "image/jpeg",
+        contentType: "image/jpeg",
         fileSize: 102400,
-        imageUrl: "data:image/jpeg;base64,test",
+        filePath: "books/123-uuid.jpg",
         createdAt: "2024-01-01T00:00:00Z",
         updatedAt: "2024-01-01T00:00:00Z",
       };
@@ -223,7 +223,7 @@ describe("ImageUpload Component", () => {
 
       expect(screen.getByText("existing.jpg")).toBeInTheDocument();
       const preview = screen.getByAltText("Preview");
-      expect(preview).toHaveAttribute("src", "data:image/jpeg;base64,test");
+      expect(preview.getAttribute("src")).toContain("/static/images/books/123-uuid.jpg");
     });
   });
 

--- a/MediaSet.Remix/app/components/image-upload.tsx
+++ b/MediaSet.Remix/app/components/image-upload.tsx
@@ -9,13 +9,14 @@ type ImageUploadProps = FormProps & {
 
 export default function ImageUpload(props: ImageUploadProps) {
   const [previewUrl, setPreviewUrl] = useState<string | null>(
-    props.existingImage?.imageUrl ?? null
+    props.existingImage?.filePath ? `${import.meta.env.VITE_API_URL}/static/images/${props.existingImage.filePath}` : null
   );
   const [fileName, setFileName] = useState<string>(
     props.existingImage?.fileName ?? ""
   );
   const [dragActive, setDragActive] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [imageCleared, setImageCleared] = useState(false);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
 
   const ALLOWED_TYPES = ["image/jpeg", "image/png"];
@@ -55,6 +56,8 @@ export default function ImageUpload(props: ImageUploadProps) {
   const handleFileInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (file) {
+      // Clear the clear marker since a new file is selected
+      setImageCleared(false);
       handleFile(file);
     }
   };
@@ -84,6 +87,7 @@ export default function ImageUpload(props: ImageUploadProps) {
     setPreviewUrl(null);
     setFileName("");
     setError(null);
+    setImageCleared(true);
     if (fileInputRef.current) {
       fileInputRef.current.value = "";
     }
@@ -104,6 +108,13 @@ export default function ImageUpload(props: ImageUploadProps) {
         disabled={props.isSubmitting}
         className="hidden"
         aria-label="Upload cover image"
+      />
+
+      <input
+        id={`${props.name}-clear-marker`}
+        type="hidden"
+        name={`${props.name}-cleared`}
+        value={imageCleared ? "true" : ""}
       />
 
       <div


### PR DESCRIPTION
This pull request improves the handling of cover image uploads and removals for entities, ensuring that clearing or updating an image is correctly reflected both in the backend API and the frontend UI. The changes also update the image preview logic and tests to match the new backend file path approach.

**Image clearing and backend handling:**

* The backend now detects when a cover image is explicitly cleared (i.e., removed by the user) and deletes the old image file if necessary. This is logged for traceability.
* The edit route action checks for a "cleared" marker in the form data; if set, it removes the cover image from the entity, otherwise, it preserves the existing image if no new one is uploaded.

**Frontend form and image preview updates:**

* The `ImageUpload` component now sets the preview URL based on the file path returned by the backend rather than a base64 data URL, and includes a hidden input to mark when the image has been cleared. [[1]](diffhunk://#diff-6843575c89987937ac417f4ba23f0006963c586fd43d22afc5c58259a367b3a3L12-R19) [[2]](diffhunk://#diff-6843575c89987937ac417f4ba23f0006963c586fd43d22afc5c58259a367b3a3R113-R119)
* The component's logic ensures that selecting a new file resets the cleared marker, and clearing the image updates the marker and resets the file input. [[1]](diffhunk://#diff-6843575c89987937ac417f4ba23f0006963c586fd43d22afc5c58259a367b3a3R59-R60) [[2]](diffhunk://#diff-6843575c89987937ac417f4ba23f0006963c586fd43d22afc5c58259a367b3a3R90)

**Test updates:**

* The image upload component tests now use the new `filePath` and `contentType` fields, and check that the preview image uses the correct static URL. [[1]](diffhunk://#diff-226b850acd4a720e587880e6281b055615bd1bf6f7338e12c3e276e80a544e08L209-R211) [[2]](diffhunk://#diff-226b850acd4a720e587880e6281b055615bd1bf6f7338e12c3e276e80a544e08L226-R226)