### PR TITLE
docs: update documentation for image storage and API endpoints

### DIFF
--- a/Development/DEVELOPMENT.md
+++ b/Development/DEVELOPMENT.md
@@ -341,6 +341,84 @@ curl http://localhost:5000/lookup/Movies/upc/883929248842
 
 The UI also provides inline lookup buttons in the add/edit forms for books and movies.
 
+## Image Storage Configuration
+
+MediaSet stores cover images locally on the filesystem, providing fast access and efficient storage management.
+
+### Image Storage Setup
+
+Images are automatically set up when you start the development environment:
+
+```bash
+# The ./dev.sh script creates the image directory
+./dev.sh start
+
+# Images are stored locally in:
+./data/images/
+```
+
+### Image Configuration
+
+Image storage is configured in `appsettings.json` (already configured for local development):
+
+```json
+{
+  "ImageConfiguration": {
+    "StoragePath": "/app/data/images",
+    "MaxFileSizeMb": 5,
+    "AllowedImageExtensions": "jpg,jpeg,png",
+    "HttpTimeoutSeconds": 30,
+    "StripExifData": true
+  }
+}
+```
+
+**Configuration Options:**
+- **StoragePath**: Directory where images are stored (default: `/app/data/images` in containers)
+- **MaxFileSizeMb**: Maximum file size in megabytes (5MB by default)
+- **AllowedImageExtensions**: Comma-separated list of allowed file extensions (JPEG and PNG by default)
+- **HttpTimeoutSeconds**: Timeout for downloading images from URLs in seconds
+- **StripExifData**: Whether to remove EXIF metadata (enabled by default for privacy)
+
+### Image Directory Persistence
+
+- Images stored during development persist in `./data/images/`
+- Images remain available when containers are restarted
+- To clear all images: `./dev.sh clean --purge`
+
+### Testing Image Upload
+
+**Upload an image when creating a book:**
+
+```bash
+# Create a test image (JPEG, PNG, etc.)
+# Then POST to the API with multipart form data
+
+curl -X POST http://localhost:5000/api/books \
+  -F "entity={\"title\":\"Test Book\",\"authors\":\"[\\\"Author Name\\\"]\"}" \
+  -F "coverImage=@/path/to/image.jpg"
+```
+
+**Download an image via URL:**
+
+```bash
+curl -X POST http://localhost:5000/api/books \
+  -F "entity={\"title\":\"Test Book\",\"authors\":\"[\\\"Author Name\\\"]\"}" \
+  -F "imageUrl=https://example.com/cover.jpg"
+```
+
+**Retrieve a stored image:**
+
+```bash
+curl http://localhost:5000/api/images/books/{bookId}
+```
+
+**Delete an image:**
+
+```bash
+curl -X DELETE http://localhost:5000/api/books/{bookId}/image
+```
+
 ## Performance Tips
 
 1. **Use .dockerignore files** to exclude unnecessary files

--- a/MediaSet.Api/README.md
+++ b/MediaSet.Api/README.md
@@ -79,8 +79,32 @@ Key settings:
 - **TMDB**: Bearer token for movie metadata
 - **GiantBomb**: API key for game metadata
 - **Caching**: In-memory cache configuration
+- **Image Storage**: Local filesystem configuration for cover images
 
 See the main project [README.md](../README.md) for detailed API key setup instructions.
+
+### Image Storage Configuration
+
+Images are stored locally on the filesystem. Configure storage settings in `appsettings.json`:
+
+```json
+{
+  "ImageConfiguration": {
+    "StoragePath": "/app/data/images",
+    "MaxFileSizeMb": 5,
+    "AllowedImageExtensions": "jpg,jpeg,png",
+    "HttpTimeoutSeconds": 30,
+    "StripExifData": true
+  }
+}
+```
+
+**Key Settings:**
+- **StoragePath**: Directory where image files are stored (can be relative or absolute)
+- **MaxFileSizeMb**: Maximum file size per image in megabytes
+- **AllowedImageExtensions**: Comma-separated list of allowed file extensions
+- **HttpTimeoutSeconds**: Timeout for downloading images from URLs (seconds)
+- **StripExifData**: Whether to remove EXIF metadata from uploaded images
 
 ## Project Structure
 
@@ -98,6 +122,168 @@ MediaSet.Api/
 ├── Services/         # Core business logic services
 └── Stats/            # Statistics services
 ```
+
+## Entity Endpoints
+
+### Standard CRUD Operations
+
+All entity types (Books, Movies, Games, Music) provide the following endpoints:
+
+**List all entities:**
+```
+GET /api/{entityType}
+```
+
+**Search entities:**
+```
+GET /api/{entityType}/search?searchText={query}&orderBy={field}
+```
+
+**Get entity by ID:**
+```
+GET /api/{entityType}/{id}
+```
+
+**Create entity with optional image:**
+```
+POST /api/{entityType}
+Content-Type: multipart/form-data
+
+Form fields:
+- entity: JSON string of the entity
+- coverImage: Optional file upload
+- imageUrl: Optional URL to download image from
+```
+
+**Update entity with optional image:**
+```
+PUT /api/{entityType}/{id}
+Content-Type: multipart/form-data
+
+Form fields:
+- entity: JSON string of the updated entity
+- coverImage: Optional file upload
+- imageUrl: Optional URL to download image from
+```
+
+**Delete entity:**
+```
+DELETE /api/{entityType}/{id}
+```
+*Note: Deleting an entity automatically deletes its associated image file.*
+
+## Image Endpoints
+
+### Retrieve Cover Image
+
+```
+GET /static/images/{filePath}
+```
+
+To retrieve an image, use the `filePath` property from the entity's `coverImage` object.
+
+**Response:**
+- `200 OK`: Image file with appropriate Content-Type header (image/jpeg or image/png)
+- `404 Not Found`: Image not found
+
+**Features:**
+- HTTP caching headers included for browser caching (7-day cache)
+- Efficient static file serving
+- Compressed responses for bandwidth optimization
+
+**Example:**
+
+First, get an entity to retrieve the image path:
+```bash
+curl http://localhost:5000/api/books/507f1f77bcf86cd799439011
+```
+
+Response includes:
+```json
+{
+  "id": "507f1f77bcf86cd799439011",
+  "title": "My Book",
+  "coverImage": {
+    "fileName": "cover.jpg",
+    "filePath": "books/507f1f77bcf86cd799439011-a1b2c3d4.jpg",
+    "fileSize": 102400,
+    "mimeType": "image/jpeg"
+  }
+}
+```
+
+Then retrieve the image using the `filePath`:
+```bash
+curl http://localhost:5000/static/images/books/507f1f77bcf86cd799439011-a1b2c3d4.jpg
+```
+
+### Delete Cover Image
+
+```
+DELETE /api/{entityType}/{entityId}/image
+```
+
+**Response:**
+- `204 No Content`: Image successfully deleted
+- `404 Not Found`: Entity or image not found
+
+**Effect:**
+- Removes the image file from filesystem
+- Removes the image reference from the entity
+- Entity remains intact without image
+
+**Note:** This endpoint removes the cover image from an entity but keeps the entity itself. To delete both the entity and its image, use the entity delete endpoint.
+
+**Example:**
+```bash
+curl -X DELETE http://localhost:5000/api/books/507f1f77bcf86cd799439011/image
+```
+
+## Image Upload Features
+
+### File Upload
+
+When creating or updating an entity, include an image file in the `coverImage` multipart field:
+
+```bash
+curl -X POST http://localhost:5000/api/books \
+  -F "entity={\"title\":\"My Book\"}" \
+  -F "coverImage=@/path/to/image.jpg"
+```
+
+**Validation:**
+- File type: JPEG or PNG only
+- File size: Maximum 5MB (configurable)
+- Format: Binary image file
+
+### Image URL Download
+
+When creating or updating an entity, provide an `imageUrl` field:
+
+```bash
+curl -X POST http://localhost:5000/api/books \
+  -F "entity={\"title\":\"My Book\",\"imageUrl\":\"https://example.com/cover.jpg\"}"
+```
+
+**Behavior:**
+- Backend downloads the image from the URL
+- Image is validated (format, size)
+- Image is saved to filesystem
+- Image reference is embedded in entity
+
+**Error Handling:**
+- Returns 400 Bad Request if URL is invalid or unreachable
+- Returns 400 Bad Request if image format is not supported
+- Returns 400 Bad Request if image exceeds size limit
+
+### File Upload Takes Precedence
+
+If both `coverImage` file and `imageUrl` are provided:
+- File upload is processed
+- URL field is ignored/cleared
+- File takes precedence
+
+## Project Structure
 
 ## Testing
 

--- a/MediaSet.Remix/README.md
+++ b/MediaSet.Remix/README.md
@@ -158,6 +158,51 @@ Example:
 </div>
 ```
 
+## Cover Images
+
+MediaSet provides full support for managing cover images for all media items:
+
+### Uploading Images
+
+When adding or editing media items, you can upload cover images in three ways:
+
+1. **Upload Image File**
+   - Click the image upload section in the add/edit form
+   - Drag and drop an image file or click to browse
+   - Supported formats: JPEG, PNG
+   - Maximum size: 5MB
+   - Preview is shown before submission
+
+2. **Provide Image URL**
+   - Enter a URL to a cover image in the `imageUrl` field
+   - The backend automatically downloads and saves the image
+   - No need to download the image locally first
+
+3. **Use Lookup Result Images**
+   - When barcode lookups return image URLs, they're displayed in the form
+   - Click to use the image from the lookup result
+   - Image is automatically downloaded and saved when you submit the form
+
+### Displaying Images
+
+- Entity detail pages display cover images prominently
+- List/grid views show thumbnail images for quick browsing
+- Fallback placeholder image shown if no image is available
+- All images have descriptive alt text for accessibility
+
+### Managing Images
+
+- **Replace Image**: In the edit form, upload a new image to replace the existing one
+- **Remove Image**: Click the clear button to remove the image from an item
+- **View Full Size**: Click an image to view it at full resolution
+
+### Image Validation
+
+The frontend validates images before upload:
+- File type validation (JPEG, PNG only)
+- File size validation (5MB limit)
+- Error messages display inline for easy troubleshooting
+
 ## API Integration
 
 The frontend communicates with the MediaSet.Api backend:

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A modern, full-stack personal media library management system for organizing you
 
 - **📚 Multi-Media Support**: Manage books, movies, games, and music in one unified application
 - **🔍 Smart Metadata Lookup**: Automatic metadata retrieval using ISBN, UPC/EAN barcodes
+- **🖼️ Cover Images**: Upload cover art, download images from lookup results, or provide URLs for automatic download
 - **📱 Responsive Design**: Mobile-friendly interface built with Tailwind CSS
 - **🚀 Modern Stack**: .NET 9.0 backend API with Remix.js frontend
 - **🐳 Containerized Development**: Full Docker/Podman support with hot-reload
@@ -95,6 +96,81 @@ MediaSet includes built-in metadata lookup functionality to quickly populate ite
   - Requires descriptive User-Agent header (already configured)
   - Respects 1 request per second rate limit
   - See detailed setup in [MUSICBRAINZ_SETUP.md](MUSICBRAINZ_SETUP.md)
+
+## 📸 Cover Images
+
+MediaSet allows you to manage cover images for all your media items. Images are stored locally on the filesystem and referenced in your media database, providing fast access without storing large files in MongoDB.
+
+### Adding Cover Images
+
+You can add cover images when creating or editing media items in three ways:
+
+1. **Upload Image File**
+   - Click the "Upload Image" button in the add/edit form
+   - Supported formats: JPEG, PNG (configurable)
+   - Maximum file size: 5MB (configurable)
+   - Images are automatically validated and optimized
+
+2. **Provide Image URL**
+   - Enter a URL to a cover image in the image URL field
+   - The backend automatically downloads and validates the image
+   - Useful for quickly grabbing images from online sources
+
+3. **Use Lookup Result Images**
+   - When performing barcode lookups (ISBN, UPC, EAN), the results often include cover image URLs
+   - These URLs are displayed in the add/edit form
+   - Click to use the image, which is automatically downloaded and saved
+
+### Image Storage
+
+- **Location**: Images are stored in `/data/images/{mediaType}/{entityId}-{guid}.{ext}`
+- **Persistence**: Images persist across container restarts and application updates
+- **Backup**: Include the `./data/images` directory in your backups
+- **File Size**: Uses minimal storage with 5MB limit per image
+
+### Configuration
+
+Image storage settings are configured in `appsettings.json`:
+
+```json
+{
+  "ImageConfiguration": {
+    "StoragePath": "/app/data/images",
+    "MaxFileSizeMb": 5,
+    "AllowedImageExtensions": "jpg,jpeg,png",
+    "HttpTimeoutSeconds": 30,
+    "StripExifData": true
+  }
+}
+```
+
+### Image Endpoints
+
+The API provides the following endpoints for image management:
+
+**Retrieve cover image:**
+```
+GET /static/images/{filePath}
+```
+Where `filePath` comes from the entity's `coverImage.filePath` property. Images are served with 7-day HTTP caching headers for optimal performance.
+
+**Remove cover image from entity:**
+```
+DELETE /api/{entityType}/{entityId}/image
+```
+This removes the image from the entity but keeps the entity intact. Images are also automatically deleted when the media item is deleted or when the entity is updated with a new image.
+
+**Example:**
+```bash
+# Get entity with image reference
+curl http://localhost:5000/api/books/507f1f77bcf86cd799439011
+
+# Retrieve the image using filePath from coverImage object
+curl http://localhost:5000/static/images/books/507f1f77bcf86cd799439011-a1b2c3d4.jpg
+
+# Remove image from entity
+curl -X DELETE http://localhost:5000/api/books/507f1f77bcf86cd799439011/image
+```
 
 ## 🚀 Getting Started
 
@@ -276,7 +352,7 @@ docs: update README with versioning policy
 feat(api)!: change health endpoint response format
 ```
 
-## 🛠️ Technology Stack
+## 🔖 Versioning
 
 **Backend:**
 - .NET 9.0 Web API


### PR DESCRIPTION
- Add Cover Images section to main README with configuration and usage details
- Document ImageConfiguration properties (StoragePath, MaxFileSizeMb, AllowedImageExtensions, HttpTimeoutSeconds, StripExifData)
- Update API README with image endpoints documentation including retrieve and delete endpoints
- Add examples showing how to retrieve images using filePath from coverImage object
- Document image upload features and validation (file type, size limits)
- Add Image Storage Configuration section to Development guide with setup instructions
- Update frontend README with cover image management features and validation
- Clarify image retrieval via /static/images/{filePath} endpoint instead of /api/images

closes #374

[AI-assisted]