### PR TITLE
feat(api): add Id and fix FileName on Image data closes #391

### DIFF
--- a/MediaSet.Api.Tests/Entities/EntityApiControllerImageTests.cs
+++ b/MediaSet.Api.Tests/Entities/EntityApiControllerImageTests.cs
@@ -98,7 +98,8 @@ public class EntityApiControllerImageTests : IntegrationTestBase
         var imageFile = CreateImageFile("test-image.jpg", "image/jpeg");
         var imageData = new Image
         {
-            FileName = "test-image.jpg",
+            Id = "guid",
+            FileName = "507f1f77bcf86cd799439011-guid.jpg",
             FilePath = "games/507f1f77bcf86cd799439011-guid.jpg",
             ContentType = "image/jpeg",
             FileSize = 1024,
@@ -190,7 +191,8 @@ public class EntityApiControllerImageTests : IntegrationTestBase
         var existingGame = _gameFaker!.Clone().RuleFor(g => g.Id, gameId).Generate();
         existingGame.CoverImage = new Image
         {
-            FileName = "old-image.jpg",
+            Id = "old-guid",
+            FileName = "507f1f77bcf86cd799439011-old-guid.jpg",
             FilePath = "games/507f1f77bcf86cd799439011-old-guid.jpg",
             ContentType = "image/jpeg",
             FileSize = 2048,
@@ -202,7 +204,8 @@ public class EntityApiControllerImageTests : IntegrationTestBase
         var newImageFile = CreateImageFile("new-image.jpg", "image/jpeg");
         var newImageData = new Image
         {
-            FileName = "new-image.jpg",
+            Id = "new-guid",
+            FileName = "507f1f77bcf86cd799439011-new-guid.jpg",
             FilePath = "games/507f1f77bcf86cd799439011-new-guid.jpg",
             ContentType = "image/jpeg",
             FileSize = 1024,
@@ -235,7 +238,8 @@ public class EntityApiControllerImageTests : IntegrationTestBase
         var existingGame = _gameFaker!.Clone().RuleFor(g => g.Id, gameId).Generate();
         existingGame.CoverImage = new Image
         {
-            FileName = "old-image.jpg",
+            Id = "old-guid",
+            FileName = "507f1f77bcf86cd799439011-old-guid.jpg",
             FilePath = "games/507f1f77bcf86cd799439011-old-guid.jpg",
             ContentType = "image/jpeg",
             FileSize = 2048,
@@ -295,7 +299,8 @@ public class EntityApiControllerImageTests : IntegrationTestBase
         var gameWithImage = _gameFaker!.Clone().RuleFor(g => g.Id, gameId).Generate();
         gameWithImage.CoverImage = new Image
         {
-            FileName = "test-image.jpg",
+            Id = "guid",
+            FileName = "507f1f77bcf86cd799439011-guid.jpg",
             FilePath = "games/507f1f77bcf86cd799439011-guid.jpg",
             ContentType = "image/jpeg",
             FileSize = 1024,
@@ -361,7 +366,8 @@ public class EntityApiControllerImageTests : IntegrationTestBase
         var gameWithImage = _gameFaker!.Clone().RuleFor(g => g.Id, gameId).Generate();
         gameWithImage.CoverImage = new Image
         {
-            FileName = "test-image.jpg",
+            Id = "guid",
+            FileName = "507f1f77bcf86cd799439011-guid.jpg",
             FilePath = "games/507f1f77bcf86cd799439011-guid.jpg",
             ContentType = "image/jpeg",
             FileSize = 1024,
@@ -396,7 +402,8 @@ public class EntityApiControllerImageTests : IntegrationTestBase
         var imageUrl = "https://example.com/image.jpg";
         var imageData = new Image
         {
-            FileName = "image.jpg",
+            Id = "guid",
+            FileName = "507f1f77bcf86cd799439011-guid.jpg",
             FilePath = "games/507f1f77bcf86cd799439011-guid.jpg",
             ContentType = "image/jpeg",
             FileSize = 1024,
@@ -447,7 +454,8 @@ public class EntityApiControllerImageTests : IntegrationTestBase
         var existingGame = _gameFaker!.Clone().RuleFor(g => g.Id, gameId).Generate();
         existingGame.CoverImage = new Image
         {
-            FileName = "old-image.jpg",
+            Id = "old-guid",
+            FileName = "507f1f77bcf86cd799439011-old-guid.jpg",
             FilePath = "games/507f1f77bcf86cd799439011-old-guid.jpg",
             ContentType = "image/jpeg",
             FileSize = 2048,
@@ -459,7 +467,8 @@ public class EntityApiControllerImageTests : IntegrationTestBase
         var imageUrl = "https://example.com/new-image.jpg";
         var newImageData = new Image
         {
-            FileName = "new-image.jpg",
+            Id = "new-guid",
+            FileName = "507f1f77bcf86cd799439011-new-guid.jpg",
             FilePath = "games/507f1f77bcf86cd799439011-new-guid.jpg",
             ContentType = "image/jpeg",
             FileSize = 1024,

--- a/MediaSet.Api.Tests/Services/ImageServiceTests.cs
+++ b/MediaSet.Api.Tests/Services/ImageServiceTests.cs
@@ -142,7 +142,8 @@ public class ImageServiceTests : IDisposable
 
         // Assert
         Assert.That(result, Is.Not.Null);
-        Assert.That(result.FileName, Is.EqualTo(fileName));
+        Assert.That(result.Id, Is.Not.Null.And.Not.Empty);
+        Assert.That(result.FileName, Does.Match($@"^{entityId}-[a-f0-9\-]+\.jpg$"));
         Assert.That(result.ContentType, Is.EqualTo("image/jpeg"));
         Assert.That(result.FileSize, Is.EqualTo(fileContent.Length));
         Assert.That(result.FilePath, Does.StartWith(entityType));

--- a/MediaSet.Api/Models/Image.cs
+++ b/MediaSet.Api/Models/Image.cs
@@ -8,7 +8,12 @@ namespace MediaSet.Api.Models
     public class Image
     {
         /// <summary>
-        /// The original filename of the uploaded image.
+        /// The unique identifier (GUID) for the saved image file.
+        /// </summary>
+        public string Id { get; set; } = string.Empty;
+
+        /// <summary>
+        /// The saved filename of the image in the format {entityId}-{id}.{extension}.
         /// </summary>
         public string FileName { get; set; } = string.Empty;
 

--- a/MediaSet.Api/Services/ImageService.cs
+++ b/MediaSet.Api/Services/ImageService.cs
@@ -95,7 +95,8 @@ public class ImageService : IImageService
                 };
             }
 
-            var uniqueFileName = $"{entityId}-{Guid.NewGuid()}.{extension}";
+            var imageId = Guid.NewGuid().ToString();
+            var uniqueFileName = $"{entityId}-{imageId}.{extension}";
             var relativePath = Path.Combine(entityType, uniqueFileName);
 
             // Save to storage
@@ -106,7 +107,8 @@ public class ImageService : IImageService
             // Return image metadata
             return new Image
             {
-                FileName = file.FileName,
+                Id = imageId,
+                FileName = uniqueFileName,
                 FilePath = relativePath,
                 ContentType = file.ContentType,
                 FileSize = imageData.Length,
@@ -185,7 +187,8 @@ public class ImageService : IImageService
             }
 
             // Generate relative path: {entityType}/{entityId}-{guid}.{ext}
-            var uniqueFileName = $"{entityId}-{Guid.NewGuid()}.{fileExtension}";
+            var imageId = Guid.NewGuid().ToString();
+            var uniqueFileName = $"{entityId}-{imageId}.{fileExtension}";
             var relativePath = Path.Combine(entityType, uniqueFileName);
 
             // Save to storage
@@ -197,7 +200,8 @@ public class ImageService : IImageService
             // Return image metadata
             return new Image
             {
-                FileName = Path.GetFileName(new Uri(imageUrl).LocalPath),
+                Id = imageId,
+                FileName = uniqueFileName,
                 FilePath = relativePath,
                 ContentType = fileExtension == "png" ? "image/png" : "image/jpeg",
                 FileSize = imageData.Length,


### PR DESCRIPTION
- Add Id property to Image model to store the generated GUID
- Update FileName property to store the saved filename (format: {entityId}-{id}.{extension})
- Modify SaveImageAsync to extract and set the Id from generated filename
- Modify DownloadAndSaveImageAsync to extract and set the Id from generated filename
- Update tests to verify Id is set and FileName contains saved filename format

[AI-assisted]