### PR TITLE
feat(ui): display cover images on list view closes #390

### DIFF
--- a/MediaSet.Remix/app/components/image-display.tsx
+++ b/MediaSet.Remix/app/components/image-display.tsx
@@ -7,11 +7,12 @@ type ImageDisplayProps = {
   alt: string;
   entityType?: Entity;
   entityId?: string;
-  size?: "small" | "medium" | "large" | "responsive";
+  size?: "xsmall" | "small" | "medium" | "large" | "responsive";
   className?: string;
 };
 
 const sizeMap = {
+  xsmall: "h-16 w-16",
   small: "h-32 w-32",
   medium: "h-48 w-48",
   large: "h-64 w-64",

--- a/MediaSet.Remix/app/helpers.test.ts
+++ b/MediaSet.Remix/app/helpers.test.ts
@@ -197,7 +197,7 @@ describe('helpers.ts', () => {
           authors: ['Author 1', 'Author 2'],
           isbn: '978-1234567890',
           publisher: 'Test Publisher',
-          pages: '300',
+          pages: 300,
           format: 'Hardcover',
           genres: ['Fiction', 'Mystery'],
           publicationDate: '2023-01-15',
@@ -261,7 +261,7 @@ describe('helpers.ts', () => {
           genres: ['Action', 'Thriller'],
           releaseDate: '2023-06-15',
           plot: 'An epic adventure',
-          runtime: '120',
+          runtime: 120,
           isTvSeries: false,
           id: '456',
         });

--- a/MediaSet.Remix/app/helpers.ts
+++ b/MediaSet.Remix/app/helpers.ts
@@ -65,6 +65,7 @@ export function millisecondsToMinutesSeconds(milliseconds: number | null | undef
 
 function baseToBookEntity(data: BaseEntity): BookEntity {
   const book = data as Book;
+  const pages = book.pages ? parseInt(String(book.pages), 10) : undefined;
   return {
     type: book.type,
     authors: book.authors ? book.authors.split(',') : undefined,
@@ -72,7 +73,7 @@ function baseToBookEntity(data: BaseEntity): BookEntity {
     genres: book.genres ? book.genres.split(',') : undefined,
     id: getValue(book.id),
     isbn: getValue(book.isbn),
-    pages: getValue(book.pages),
+    pages: isNaN(pages || NaN) ? undefined : pages,
     plot: getValue(book.plot),
     publicationDate: getValue(book.publicationDate),
     publisher: getValue(book.publisher),
@@ -85,6 +86,7 @@ function baseToBookEntity(data: BaseEntity): BookEntity {
 function baseToMovieEntity(data: BaseEntity): MovieEntity {
   const movie = data as Movie;
   const isTvSeries = (movie.isTvSeries as unknown) as string;
+  const runtime = movie.runtime ? parseInt(String(movie.runtime), 10) : undefined;
   return {
     type: movie.type,
     studios: movie.studios ? movie.studios.split(',') : undefined,
@@ -94,7 +96,7 @@ function baseToMovieEntity(data: BaseEntity): MovieEntity {
     barcode: getValue(movie.barcode),
     releaseDate: getValue(movie.releaseDate),
     plot: getValue(movie.plot),
-    runtime: getValue(movie.runtime),
+    runtime: isNaN(runtime || NaN) ? undefined : runtime,
     title: getValue(movie.title),
     isTvSeries: getValue(isTvSeries) ? true : false,
     imageUrl: getValue(movie.imageUrl),
@@ -151,6 +153,8 @@ function baseToMusicEntity(data: BaseEntity): MusicEntity {
   
   // Convert overall duration from MM:SS to milliseconds
   const durationMs = music.duration ? durationToMilliseconds(music.duration as any) : undefined;
+  const tracks = music.tracks ? parseInt(String(music.tracks), 10) : undefined;
+  const discs = music.discs ? parseInt(String(music.discs), 10) : undefined;
   
   return {
     type: music.type,
@@ -163,8 +167,8 @@ function baseToMusicEntity(data: BaseEntity): MusicEntity {
     duration: durationMs ?? undefined,
     label: getValue(music.label),
     barcode: getValue(music.barcode),
-    tracks: getValue(music.tracks),
-    discs: getValue(music.discs),
+    tracks: isNaN(tracks || NaN) ? undefined : tracks,
+    discs: isNaN(discs || NaN) ? undefined : discs,
     discList: discList.length > 0 ? discList : undefined,
     imageUrl: getValue(music.imageUrl),
   };

--- a/MediaSet.Remix/app/routes/$entity._index/books.test.tsx
+++ b/MediaSet.Remix/app/routes/$entity._index/books.test.tsx
@@ -64,6 +64,7 @@ describe('Books component', () => {
 
       expect(screen.getByRole('table')).toBeInTheDocument();
       expect(screen.getByText('Title')).toBeInTheDocument();
+      expect(screen.getByText('Cover')).toBeInTheDocument();
       expect(screen.getByText('Authors')).toBeInTheDocument();
       expect(screen.getByText('Format')).toBeInTheDocument();
       expect(screen.getByText('Pages')).toBeInTheDocument();

--- a/MediaSet.Remix/app/routes/$entity._index/books.tsx
+++ b/MediaSet.Remix/app/routes/$entity._index/books.tsx
@@ -2,7 +2,8 @@ import { Link } from "@remix-run/react";
 import { Pencil, Trash2 } from "lucide-react";
 import { useState } from "react";
 import DeleteDialog from "~/components/delete-dialog";
-import { BookEntity } from "~/models";
+import ImageDisplay from "~/components/image-display";
+import { BookEntity, Entity } from "~/models";
 
 type BooksProps = {
   books: BookEntity[]
@@ -19,6 +20,7 @@ export default function Books({ books }: BooksProps) {
       <table className="text-left w-full">
         <thead className="dark:bg-zinc-700 border-b-2 border-slate-600">
           <tr>
+            <th className="hidden md:table-cell pl-2 p-1 border-r border-slate-800 underline">Cover</th>
             <th className="pl-2 p-1 border-r border-slate-800 underline">Title</th>
             <th className="hidden xs:table-cell pl-2 p-1 border-r border-slate-800 underline">Authors</th>
             <th className="hidden md:table-cell pl-2 p-1 border-r border-slate-800 underline">Format</th>
@@ -30,6 +32,9 @@ export default function Books({ books }: BooksProps) {
           {books.map(book => {
             return (
               <tr className="border-b border-slate-700 dark:hover:bg-zinc-800" key={book.id}>
+                <td className="hidden md:table-cell w-16 pl-2 p-1 border-r border-slate-800">
+                  {book.coverImage && <ImageDisplay imageData={book.coverImage} alt={`${book.title} cover`} entityType={Entity.Books} entityId={book.id} size="xsmall" />}
+                </td>
                 <td className="pl-2 p-1 border-r border-slate-800">
                   <Link to={`/books/${book.id}`}>{book.title}{book.subtitle && `: ${book.subtitle}`}</Link>
                 </td>

--- a/MediaSet.Remix/app/routes/$entity._index/games.tsx
+++ b/MediaSet.Remix/app/routes/$entity._index/games.tsx
@@ -2,7 +2,8 @@ import { Link } from "@remix-run/react";
 import { Pencil, Trash2 } from "lucide-react";
 import { useState } from "react";
 import DeleteDialog from "~/components/delete-dialog";
-import { GameEntity } from "~/models";
+import ImageDisplay from "~/components/image-display";
+import { GameEntity, Entity } from "~/models";
 
 type GamesProps = {
   games: GameEntity[]
@@ -19,6 +20,7 @@ export default function Games({ games }: GamesProps) {
       <table className="text-left w-full">
         <thead className="dark:bg-zinc-700 border-b-2 border-slate-600">
           <tr>
+            <th className="hidden md:table-cell pl-2 p-1 border-r border-slate-800 underline">Cover</th>
             <th className="pl-2 p-1 border-r border-slate-800 underline">Title</th>
             <th className="hidden md:table-cell pl-2 p-1 border-r border-slate-800 underline">Platform</th>
             <th className="hidden lg:table-cell pl-2 p-1 border-r border-slate-800 underline">Format</th>
@@ -30,6 +32,9 @@ export default function Games({ games }: GamesProps) {
           {games.map(game => {
             return (
               <tr className="border-b border-slate-700 dark:hover:bg-zinc-800" key={game.id}>
+                <td className="hidden md:table-cell w-16 pl-2 p-1 border-r border-slate-800">
+                  {game.coverImage && <ImageDisplay imageData={game.coverImage} alt={`${game.title} cover`} entityType={Entity.Games} entityId={game.id} size="xsmall" />}
+                </td>
                 <td className="pl-2 p-1 border-r border-slate-800">
                   <Link to={`/games/${game.id}`}>{game.title}</Link>
                 </td>

--- a/MediaSet.Remix/app/routes/$entity._index/movies.tsx
+++ b/MediaSet.Remix/app/routes/$entity._index/movies.tsx
@@ -3,7 +3,8 @@ import { Link } from "@remix-run/react";
 import { Pencil, Trash2, Check } from "lucide-react";
 import { useState } from "react";
 import DeleteDialog from "~/components/delete-dialog";
-import { MovieEntity } from "~/models";
+import ImageDisplay from "~/components/image-display";
+import { MovieEntity, Entity } from "~/models";
 
 type MovieProps = {
   movies: MovieEntity[]
@@ -20,6 +21,7 @@ export default function Movies({ movies }: MovieProps) {
       <table className="text-left w-full">
         <thead className="dark:bg-zinc-700 border-b-2 border-slate-600">
           <tr>
+            <th className="hidden md:table-cell pl-2 p-1 border-r border-slate-800 underline">Cover</th>
             <th className="pl-2 p-1 border-r border-slate-800 underline">Title</th>
             <th className="hidden md:table-cell pl-2 p-1 border-r border-slate-800 underline">Format</th>
             <th className="hidden lg:table-cell pl-2 p-1 border-r border-slate-800 underline">Runtime</th>
@@ -31,6 +33,9 @@ export default function Movies({ movies }: MovieProps) {
           {movies.map(movie => {
             return (
               <tr className="border-b border-slate-700 dark:hover:bg-zinc-800" key={movie.id}>
+                <td className="hidden md:table-cell w-16 pl-2 p-1 border-r border-slate-800">
+                  {movie.coverImage && <ImageDisplay imageData={movie.coverImage} alt={`${movie.title} cover`} entityType={Entity.Movies} entityId={movie.id} size="xsmall" />}
+                </td>
                 <td className="pl-2 p-1 border-r border-slate-800">
                   <Link to={`/movies/${movie.id}`}>{movie.title}</Link>
                 </td>

--- a/MediaSet.Remix/app/routes/$entity._index/musics.tsx
+++ b/MediaSet.Remix/app/routes/$entity._index/musics.tsx
@@ -2,7 +2,8 @@ import { Link } from "@remix-run/react";
 import { Pencil, Trash2 } from "lucide-react";
 import { useState } from "react";
 import DeleteDialog from "~/components/delete-dialog";
-import { MusicEntity } from "~/models";
+import ImageDisplay from "~/components/image-display";
+import { MusicEntity, Entity } from "~/models";
 
 type MusicsProps = {
   musics: MusicEntity[]
@@ -19,6 +20,7 @@ export default function Musics({ musics }: MusicsProps) {
       <table className="text-left w-full">
         <thead className="dark:bg-zinc-700 border-b-2 border-slate-600">
           <tr>
+            <th className="hidden md:table-cell pl-2 p-1 border-r border-slate-800 underline">Cover</th>
             <th className="pl-2 p-1 border-r border-slate-800 underline">Title</th>
             <th className="hidden md:table-cell pl-2 p-1 border-r border-slate-800 underline">Artist</th>
             <th className="hidden lg:table-cell pl-2 p-1 border-r border-slate-800 underline">Format</th>
@@ -30,6 +32,9 @@ export default function Musics({ musics }: MusicsProps) {
           {musics.map(music => {
             return (
               <tr className="border-b border-slate-700 dark:hover:bg-zinc-800" key={music.id}>
+                <td className="hidden md:table-cell w-16 pl-2 p-1 border-r border-slate-800">
+                  {music.coverImage && <ImageDisplay imageData={music.coverImage} alt={`${music.title} cover`} entityType={Entity.Musics} entityId={music.id} size="xsmall" />}
+                </td>
                 <td className="pl-2 p-1 border-r border-slate-800">
                   <Link to={`/musics/${music.id}`}>{music.title}</Link>
                 </td>

--- a/MediaSet.Remix/app/routes/$entity_.$entityId_.edit/route.tsx
+++ b/MediaSet.Remix/app/routes/$entity_.$entityId_.edit/route.tsx
@@ -69,9 +69,23 @@ export const action = async ({ request, params }: ActionFunctionArgs) => {
   if (imageClearedMarker === "true") {
     // Image was cleared, remove it
     entity.coverImage = undefined;
-  } else if (existingEntity?.coverImage) {
-    // No new image selected and not cleared, preserve existing image
-    entity.coverImage = existingEntity.coverImage;
+  } else {
+    // Check if coverImage data was submitted as hidden fields
+    const coverImageFileName = formData.get("coverImage-fileName") as string | null;
+    if (coverImageFileName) {
+      // Reconstruct coverImage from hidden inputs
+      entity.coverImage = {
+        fileName: coverImageFileName,
+        contentType: (formData.get("coverImage-contentType") as string) || "",
+        fileSize: parseInt((formData.get("coverImage-fileSize") as string) || "0"),
+        filePath: (formData.get("coverImage-filePath") as string) || "",
+        createdAt: (formData.get("coverImage-createdAt") as string) || "",
+        updatedAt: (formData.get("coverImage-updatedAt") as string) || "",
+      };
+    } else if (existingEntity?.coverImage) {
+      // No new image selected and not cleared, preserve existing image
+      entity.coverImage = existingEntity.coverImage;
+    }
   }
 
   // Check if there's an image file to send as multipart/form-data


### PR DESCRIPTION
- Add xsmall size (h-16 w-16) to ImageDisplay component
- Display cover images on all entity list views (Books, Games, Movies, Musics)
- Hide images on mobile, visible on medium screens and up
- Move cover column to first position in tables
- Add image metadata serialization to preserve ID during entity edits
- Parse numeric form fields (pages, runtime, tracks, discs) to ensure API compatibility

[AI-assisted]