### PR TITLE
feat(api): strip EXIF data from uploaded and downloaded images closes #389

### DIFF
--- a/MediaSet.Api.Tests/appsettings.Testing.json
+++ b/MediaSet.Api.Tests/appsettings.Testing.json
@@ -24,8 +24,7 @@
     "MaxFileSizeMb": 5,
     "AllowedImageExtensions": "jpg,jpeg,png",
     "HttpTimeoutSeconds": 30,
-    "MaxDownloadSizeMb": 10,
-    "StripExifData": true
+    "MaxDownloadSizeMb": 10
   },
   "OpenLibraryConfiguration": {
     "BaseUrl": "https://openlibrary.org",

--- a/MediaSet.Api/MediaSet.Api.csproj
+++ b/MediaSet.Api/MediaSet.Api.csproj
@@ -19,6 +19,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="MongoDB.Driver" Version="3.0.0" />
+        <PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     </ItemGroup>
 

--- a/MediaSet.Api/Models/ImageConfiguration.cs
+++ b/MediaSet.Api/Models/ImageConfiguration.cs
@@ -26,11 +26,6 @@ public class ImageConfiguration
     public int HttpTimeoutSeconds { get; set; } = 30;
 
     /// <summary>
-    /// Whether to strip EXIF data from uploaded images. Default: true.
-    /// </summary>
-    public bool StripExifData { get; set; } = true;
-
-    /// <summary>
     /// Get the maximum file size in bytes.
     /// </summary>
     public long GetMaxFileSizeBytes() => MaxFileSizeMb * 1024L * 1024L;

--- a/MediaSet.Api/appsettings.Development.json
+++ b/MediaSet.Api/appsettings.Development.json
@@ -19,8 +19,7 @@
     "MaxFileSizeMb": 5,
     "AllowedImageExtensions": "jpg,jpeg,png",
     "HttpTimeoutSeconds": 30,
-    "MaxDownloadSizeMb": 10,
-    "StripExifData": true
+    "MaxDownloadSizeMb": 10
   },
   "UpcItemDbConfiguration": {
     "BaseUrl": "https://api.upcitemdb.com/",

--- a/MediaSet.Api/appsettings.json
+++ b/MediaSet.Api/appsettings.json
@@ -17,8 +17,7 @@
     "MaxFileSizeMb": 5,
     "AllowedImageExtensions": "jpg,jpeg,png",
     "HttpTimeoutSeconds": 30,
-    "MaxDownloadSizeMb": 10,
-    "StripExifData": true
+    "MaxDownloadSizeMb": 10
   },
   "UpcItemDbConfiguration": {
     "BaseUrl": "https://api.upcitemdb.com/",


### PR DESCRIPTION
- Add SixLabors.ImageSharp NuGet package for image processing
- Always strip EXIF data from images for privacy protection (not configurable)
- Remove StripExifData configuration property and settings
- Save images in original format (PNG/JPEG) after stripping metadata