### PR TITLE
fix(build): align .NET SDK to 9.0.112 across all environments

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '9.0.305'
+          global-json-file: global.json
       
       - name: Restore dependencies
         run: dotnet restore

--- a/MediaSet.Api/Dockerfile
+++ b/MediaSet.Api/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:9.0.112 AS build
 WORKDIR /src
 
 # Accept version from build args (passed by CI/CD)


### PR DESCRIPTION
- Update GitHub Actions pr-checks workflow to use global.json for SDK version
- Pin Dockerfile to use SDK 9.0.112 instead of floating 9.0 tag
- Ensures consistent build behavior between local, CI, and Docker builds

This resolves the build failure where Docker was using SDK 9.0.310 while local development was on 9.0.112.

[AI-assisted]