### PR TITLE
fix(build): change rollForward to latestFeature for cross-feature-ban…

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
     "version": "9.0.112",
-    "rollForward": "latestPatch"
+    "rollForward": "latestFeature"
   }
 }


### PR DESCRIPTION
…d compatibility

latestPatch only allows patches within same feature band (9.0.1xx). latestFeature allows any feature band within same minor version (9.0.x).

This enables Docker with SDK 9.0.310 to work with local SDK 9.0.112.

[AI-assisted]