### PR TITLE
fix(dev-env): stabilize podman builds

### DIFF
--- a/MediaSet.Api/Dockerfile.dev
+++ b/MediaSet.Api/Dockerfile.dev
@@ -3,6 +3,9 @@ FROM mcr.microsoft.com/dotnet/sdk:10.0 AS development
 
 WORKDIR /app
 
+# Clear NuGet cache to prevent restore issues in local development
+RUN dotnet nuget locals all --clear
+
 # Install debugger
 RUN curl -sSL https://aka.ms/getvsdbgsh | bash /dev/stdin -v latest -l /vsdbg
 

--- a/MediaSet.Api/HealthApi.cs
+++ b/MediaSet.Api/HealthApi.cs
@@ -22,6 +22,7 @@ internal static class HealthApi
 
             try
             {
+                logger.LogInformation("Pinging MongoDB database: {DatabaseName}", dbName);
                 // Obtain database from any collection; Database property points to the configured IMongoDatabase
                 var collection = databaseService.GetCollection<BsonDocument>();
                 var database = collection.Database;


### PR DESCRIPTION
This pull request enhances local development reliability and developer experience for the MediaSet project, focusing on build stability and resource management. The main improvements are automatic NuGet cache clearing to prevent restore issues, better support for clean rebuilds, and Podman-specific image pruning to avoid disk space bloat. The developer CLI (`dev.sh`) now includes new commands and usage documentation to make these features accessible.

**Development environment reliability and resource management:**

* Added automatic clearing of the NuGet cache in both the `Dockerfile.dev` and the `dev.sh` script to prevent package restore issues during local development. (`MediaSet.Api/Dockerfile.dev`, `dev.sh`) [[1]](diffhunk://#diff-da1e46ed69c8ebcab7481698aa0cd2ac023a7f570a96cf1a37cb45f873d2a83aR6-R8) [[2]](diffhunk://#diff-e467af283c7153901d6c6e177357377485e8f52e407d7eb9eeb172721520824aR203-R238)
* Implemented Podman-specific image pruning in `dev.sh` to automatically remove dangling images after starting or stopping containers, with an environment variable (`PODMAN_AUTO_PRUNE=0`) to disable this if needed. (`dev.sh`) [[1]](diffhunk://#diff-e467af283c7153901d6c6e177357377485e8f52e407d7eb9eeb172721520824aR343-R358) [[2]](diffhunk://#diff-e467af283c7153901d6c6e177357377485e8f52e407d7eb9eeb172721520824aR307-R314)

**Developer CLI usability improvements:**

* Added support for clean rebuilds with the `--clean` flag on `start` and a new `rebuild` command that purges containers, images, and caches before rebuilding everything from scratch. (`dev.sh`) [[1]](diffhunk://#diff-e467af283c7153901d6c6e177357377485e8f52e407d7eb9eeb172721520824aR203-R238) [[2]](diffhunk://#diff-e467af283c7153901d6c6e177357377485e8f52e407d7eb9eeb172721520824aL365-R431) [[3]](diffhunk://#diff-e467af283c7153901d6c6e177357377485e8f52e407d7eb9eeb172721520824aR484-R499)
* Expanded CLI help output to document new commands (`rebuild`, `cache-clean`), flags, and environment variables, making it easier for developers to troubleshoot and maintain their environment. (`dev.sh`) [[1]](diffhunk://#diff-e467af283c7153901d6c6e177357377485e8f52e407d7eb9eeb172721520824aL365-R431) [[2]](diffhunk://#diff-e467af283c7153901d6c6e177357377485e8f52e407d7eb9eeb172721520824aR441-R458)

**Operational logging:**

* Added an informational log statement to the health check endpoint to indicate when a MongoDB ping is performed, aiding in debugging and monitoring. (`MediaSet.Api/HealthApi.cs`)

closes #277

[AI-assisted]