### PR TITLE
fix(api): handle image save failures gracefully closes #401

### DIFF
--- a/MediaSet.Api.Tests/Entities/EntityApiControllerImageTests.cs
+++ b/MediaSet.Api.Tests/Entities/EntityApiControllerImageTests.cs
@@ -264,7 +264,7 @@ public class EntityApiControllerImageTests : IntegrationTestBase
     }
 
     [Test]
-    public async Task UpdateGameWithImageUploadFailure_ShouldReturnBadRequest()
+    public async Task UpdateGameWithImageUploadFailure_ShouldStillUpdateEntity()
     {
         // Arrange
         var gameId = "507f1f77bcf86cd799439011";
@@ -284,7 +284,8 @@ public class EntityApiControllerImageTests : IntegrationTestBase
         var response = await _client!.PutAsync($"/Games/{gameId}", content);
 
         // Assert
-        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest));
+        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK));
+        _gameServiceMock.Verify(s => s.UpdateAsync(gameId, It.IsAny<Game>(), It.IsAny<CancellationToken>()), Times.Once);
     }
 
     #endregion

--- a/MediaSet.Api/Entities/EntityApi.cs
+++ b/MediaSet.Api/Entities/EntityApi.cs
@@ -291,7 +291,7 @@ internal static class EntityApi
                         catch (ArgumentException ex)
                         {
                             logger.LogWarning("Image validation failed: {error}", ex.Message);
-                            return TypedResults.BadRequest($"Image validation failed: {ex.Message}");
+                            // Continue anyway - entity update should succeed even if image fails
                         }
                         
                         // Ensure imageUrl is not persisted when a file is uploaded (file takes precedence)
@@ -316,12 +316,12 @@ internal static class EntityApi
                         catch (ArgumentException ex)
                         {
                             logger.LogWarning("Failed to download image from URL: {error}", ex.Message);
-                            return TypedResults.BadRequest($"Failed to download image: {ex.Message}");
+                            // Continue anyway - entity update should succeed even if image fails
                         }
                         catch (HttpRequestException ex)
                         {
                             logger.LogWarning("HTTP error downloading image: {error}", ex.Message);
-                            return TypedResults.BadRequest($"Failed to download image from URL: {ex.Message}");
+                            // Continue anyway - entity update should succeed even if image fails
                         }
                     }
                     else if (updatedEntity.CoverImage is null && existingEntity.CoverImage is not null)
@@ -355,12 +355,12 @@ internal static class EntityApi
                         catch (ArgumentException ex)
                         {
                             logger.LogWarning("Failed to download image from URL: {error}", ex.Message);
-                            return TypedResults.BadRequest($"Failed to download image: {ex.Message}");
+                            // Continue anyway - entity update should succeed even if image fails
                         }
                         catch (HttpRequestException ex)
                         {
                             logger.LogWarning("HTTP error downloading image: {error}", ex.Message);
-                            return TypedResults.BadRequest($"Failed to download image from URL: {ex.Message}");
+                            // Continue anyway - entity update should succeed even if image fails
                         }
                     }
                     // Check if image is being cleared (updatedEntity.CoverImage is null but existing had one)


### PR DESCRIPTION
When updating an entity, if the image save fails (file upload or URL download), continue with the entity update and log a warning instead of returning BadRequest. This matches the behavior already implemented for entity creation.

Changes:
- EntityApi.cs: Updated PUT endpoint to log warnings and continue when image processing fails, rather than returning BadRequest
- EntityApiControllerImageTests.cs: Updated test to verify entity update succeeds even when image upload fails

[AI-assisted]