### PR TITLE
fix(ui): display full image without cropping in ImageDisplay closes #443

### DIFF
--- a/MediaSet.Remix/app/components/image-display.tsx
+++ b/MediaSet.Remix/app/components/image-display.tsx
@@ -103,7 +103,7 @@ export default function ImageDisplay({
             <img
               src={imagePath}
               alt={alt}
-              className="w-full h-full object-cover"
+              className="w-full h-full object-contain"
               loading="lazy"
               onError={handleImageError}
               onLoad={handleImageLoad}

--- a/MediaSet.Remix/app/tailwind.css
+++ b/MediaSet.Remix/app/tailwind.css
@@ -21,7 +21,7 @@
     @apply text-gray-400 opacity-100
   }
 
-  button:not([class~="link"]) {
+  button:not([class~="link"]):not([class~="image-button"]) {
     @apply px-3 py-1 dark:text-slate-200 dark:bg-blue-600 dark:hover:bg-blue-500 dark:disabled:bg-slate-900 dark:disabled:text-slate-500 rounded bg-white transition-colors
   }
 
@@ -42,6 +42,6 @@
   }
 
   button[class~="image-button"] {
-    @apply appearance-none bg-transparent border-0 p-0 cursor-pointer hover:opacity-75 transition-opacity
+    @apply appearance-none bg-transparent border-0 p-0 cursor-pointer hover:opacity-65 transition-opacity
   }
 }


### PR DESCRIPTION
Changed image rendering from object-cover to object-contain to display the full image regardless of aspect ratio. The image now scales down to fit within the preset container size while maintaining its aspect ratio, eliminating cropping issues for portrait and landscape images.

Also updated button selector to exclude image-button from generic button hover styles, ensuring no background hover effect on the image button.

[AI-assisted]