### PR TITLE
docs: add CLAUDE.md and update backend to .NET 10

### DIFF
--- a/.github/instructions/backend.instructions.md
+++ b/.github/instructions/backend.instructions.md
@@ -1,9 +1,9 @@
 ---
-description: Code style and conventions for .NET 9.0 backend API
+description: Code style and conventions for .NET 10 backend API
 applyTo: "**/*.cs"
 ---
 
-# .NET 9.0 Backend Code Style Guide
+# .NET 10 Backend Code Style Guide
 
 ## File Organization
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,60 @@
+# MediaSet
+
+Full-stack application for managing personal media collections.
+
+## Tech Stack
+
+- **Backend:** .NET 10 minimal API with MongoDB
+- **Frontend:** Remix.js with TypeScript and Tailwind CSS
+- **Testing:** NUnit (backend), Vitest + React Testing Library (frontend)
+
+## Project Structure
+
+- `MediaSet.Api/` — .NET backend API (Models, Services, Helpers, endpoints)
+- `MediaSet.Api.Tests/` — Backend unit tests (NUnit)
+- `MediaSet.Remix/` — Remix.js frontend UI
+- `Development/` — Docker Compose and local development configuration
+- `Setup/` — Production setup and deployment files
+- `assets/` — Static assets
+
+## Code Style & Conventions
+
+Before making changes, read and follow these instruction files:
+- `.github/copilot-instructions.md` — project-wide rules (branching, commits, workflow)
+- `.github/instructions/backend.instructions.md` — .NET code style (applies to `*.cs` files)
+- `.github/instructions/frontend.instructions.md` — Remix/TypeScript code style (applies to `*.ts`, `*.tsx` files)
+
+## Development Commands
+
+```bash
+# Start entire dev environment
+./dev.sh start
+
+# Start individual components
+./dev.sh start api           # Backend API only
+./dev.sh start frontend      # Frontend UI only
+
+# Restart / stop components
+./dev.sh restart api
+./dev.sh stop frontend
+```
+
+## Testing
+
+```bash
+# Backend tests
+dotnet test MediaSet.Api.Tests/MediaSet.Api.Tests.csproj
+
+# Frontend tests
+cd MediaSet.Remix && npm test
+
+# Frontend build
+cd MediaSet.Remix && npm run build
+```
+
+## Commit Conventions
+
+- Follow Conventional Commits: `type(scope): description`
+- Subject line must be ≤ 72 characters
+- Reference issues: `closes #N` (final), `refs #N` (intermediate)
+- Never commit directly to `main` — use feature branches


### PR DESCRIPTION
## Summary
- Add `CLAUDE.md` project instructions file for Claude Code, referencing existing code style guides and including project structure, tech stack, dev commands, and testing info
- Update backend instructions from .NET 9.0 to .NET 10 to reflect the current target framework

## Test plan
- [x] Verify `CLAUDE.md` is picked up by Claude Code at session start
- [x] Confirm backend instructions correctly reference .NET 10

🤖 Generated with [Claude Code](https://claude.com/claude-code)