### PR TITLE
fix(api): hardcode TMDB attribution text to meet API requirements

### DIFF
--- a/MediaSet.Api/Features/Config/Endpoints/ConfigApi.cs
+++ b/MediaSet.Api/Features/Config/Endpoints/ConfigApi.cs
@@ -23,7 +23,7 @@ internal static class ConfigApi
             var giantBombSection = configuration.GetSection("GiantBombConfiguration");
             var musicBrainzSection = configuration.GetSection("MusicBrainzConfiguration");
 
-            IntegrationAttributionDto Build(string key, string displayName, IConfigurationSection section, string defaultLogo)
+            IntegrationAttributionDto Build(string key, string displayName, IConfigurationSection section, string defaultLogo, string? defaultAttributionUrl = null, string? defaultAttributionText = null)
             {
                 var enabled = section.Exists();
                 return new IntegrationAttributionDto
@@ -31,15 +31,17 @@ internal static class ConfigApi
                     Key = key,
                     DisplayName = displayName,
                     Enabled = enabled,
-                    AttributionUrl = enabled ? section.GetValue<string>("AttributionUrl") : null,
-                    AttributionText = enabled ? section.GetValue<string>("AttributionText") : null,
+                    AttributionUrl = enabled ? (section.GetValue<string>("AttributionUrl") ?? defaultAttributionUrl) : null,
+                    AttributionText = enabled ? (section.GetValue<string>("AttributionText") ?? defaultAttributionText) : null,
                     LogoPath = enabled ? section.GetValue<string>("LogoPath") ?? defaultLogo : null
                 };
             }
 
             var result = new[]
             {
-                Build("tmdb", "TMDB", tmdbSection, "/integrations/tmdb.svg"),
+                Build("tmdb", "TMDB", tmdbSection, "/integrations/tmdb.svg",
+                    defaultAttributionUrl: "https://www.themoviedb.org/",
+                    defaultAttributionText: "This product uses the TMDB API but is not endorsed or certified by TMDB."),
                 Build("openlibrary", "OpenLibrary", openLibrarySection, "/integrations/openlibrary.svg"),
                 Build("upcitemdb", "UPCitemdb", upcItemDbSection, "/integrations/upcitemdb.png"),
                 Build("giantbomb", "GiantBomb", giantBombSection, "/integrations/giantbomb.svg"),


### PR DESCRIPTION
## Summary
- Hardcodes TMDB attribution URL and text in the `/config/integrations` endpoint
- Users no longer need to manually configure TMDB attribution fields
- Attribution is automatically included when TMDB is configured

## Problem
TMDB requires attribution text when using their API (issue #473). Previously, this had to be manually configured in `appsettings.json`, but users had no way of knowing this requirement since it wasn't documented in the setup guides.

## Solution
Modified `ConfigApi.cs` to accept optional default attribution parameters and hardcode TMDB's required attribution:
- **Attribution URL**: `https://www.themoviedb.org/`
- **Attribution Text**: "This product uses the TMDB API but is not endorsed or certified by TMDB."

These values are automatically used when TMDB is configured, but can still be overridden via configuration if needed.

## Test plan
- [x] All 464 backend tests pass
- [x] TMDB attribution will automatically appear when TMDB is configured
- [x] No breaking changes to existing configurations

closes #473

🤖 Generated with [Claude Code](https://claude.com/claude-code)