### PR TITLE
feat: add numeric keyboard for barcode inputs on mobile

### DIFF
--- a/MediaSet.Remix/app/components/book-form.tsx
+++ b/MediaSet.Remix/app/components/book-form.tsx
@@ -105,7 +105,7 @@ export default function BookForm({ book, authors, genres, publishers, formats, i
       <div>
         <label htmlFor="isbn" className="block text-sm font-medium text-gray-200 mb-1">ISBN</label>
         <div className="flex gap-2">
-          <input id="isbn" name="isbn" type="text" className={inputClasses} placeholder="ISBN" defaultValue={book?.isbn} aria-label="ISBN" onKeyDown={handleKeyDown} />
+          <input id="isbn" name="isbn" type="text" inputMode="numeric" className={inputClasses} placeholder="ISBN" defaultValue={book?.isbn} aria-label="ISBN" onKeyDown={handleKeyDown} />
           {isbnLookupAvailable && (
             <>
               <button

--- a/MediaSet.Remix/app/components/game-form.tsx
+++ b/MediaSet.Remix/app/components/game-form.tsx
@@ -101,7 +101,7 @@ export default function GameForm({ game, developers, publishers, genres, formats
       <div>
         <label htmlFor="barcode" className="block text-sm font-medium text-gray-200 mb-1">Barcode</label>
         <div className="flex gap-2">
-          <input id="barcode" name="barcode" type="text" className={inputClasses} placeholder="Barcode" defaultValue={game?.barcode} aria-label="Barcode" onKeyDown={handleKeyDown} />
+          <input id="barcode" name="barcode" type="text" inputMode="numeric" className={inputClasses} placeholder="Barcode" defaultValue={game?.barcode} aria-label="Barcode" onKeyDown={handleKeyDown} />
           {barcodeLookupAvailable && (
             <>
               <button

--- a/MediaSet.Remix/app/components/movie-form.tsx
+++ b/MediaSet.Remix/app/components/movie-form.tsx
@@ -104,7 +104,7 @@ export default function MovieForm({ movie, genres, studios, formats, isSubmittin
       <div>
         <label htmlFor="barcode" className="block text-sm font-medium text-gray-200 mb-1">Barcode</label>
         <div className="flex gap-2">
-          <input id="barcode" name="barcode" type="text" className={inputClasses} placeholder="Barcode" defaultValue={movie?.barcode} aria-label="Barcode" onKeyDown={handleKeyDown} />
+          <input id="barcode" name="barcode" type="text" inputMode="numeric" className={inputClasses} placeholder="Barcode" defaultValue={movie?.barcode} aria-label="Barcode" onKeyDown={handleKeyDown} />
           {barcodeLookupAvailable && (
             <>
               <button

--- a/MediaSet.Remix/app/components/music-form.tsx
+++ b/MediaSet.Remix/app/components/music-form.tsx
@@ -132,7 +132,7 @@ export default function MusicForm({ music, genres, formats, labels, isSubmitting
       <div>
         <label htmlFor="barcode" className="block text-sm font-medium text-gray-200 mb-1">Barcode</label>
         <div className="flex gap-2">
-          <input id="barcode" name="barcode" type="text" className={inputClasses} placeholder="Barcode" defaultValue={music?.barcode} aria-label="Barcode" onKeyDown={handleKeyDown} />
+          <input id="barcode" name="barcode" type="text" inputMode="numeric" className={inputClasses} placeholder="Barcode" defaultValue={music?.barcode} aria-label="Barcode" onKeyDown={handleKeyDown} />
           {barcodeLookupAvailable && (
             <>
               <button


### PR DESCRIPTION
## Description
Add inputMode='numeric' to barcode and ISBN input fields to display the numeric keypad on mobile devices for easier data entry.

## Changes
- Added inputMode='numeric' to ISBN input in book-form
- Added inputMode='numeric' to barcode inputs in game-form, movie-form, and music-form
- Maintains type='text' to support special characters (e.g., dashes in ISBNs)

## Testing
- All existing tests pass (168/168)
- Verified no compilation errors

## Related Issue
Fixes #483