### PR TITLE
fix(lookup): handle JSON parse errors in OpenLibrary client

### DIFF
--- a/MediaSet.Api.Tests/Infrastructure/Lookup/Clients/OpenLibrary/OpenLibraryClientTests.cs
+++ b/MediaSet.Api.Tests/Infrastructure/Lookup/Clients/OpenLibrary/OpenLibraryClientTests.cs
@@ -762,6 +762,42 @@ public class OpenLibraryClientTests
         Assert.That(result!.PublishDate, Is.EqualTo("2015"));
     }
 
+    [Test]
+    public async Task GetReadableBookByIsbnAsync_WithInvalidJson_ReturnsNull()
+    {
+        // Arrange
+        var isbn = "23423";
+        var invalidJson = "This is not valid JSON";
+
+        SetupHttpResponse(HttpStatusCode.OK, invalidJson);
+
+        var client = new OpenLibraryClient(_httpClient, _loggerMock.Object);
+
+        // Act
+        var result = await client.GetReadableBookByIsbnAsync(isbn);
+
+        // Assert
+        Assert.That(result, Is.Null);
+    }
+
+    [Test]
+    public async Task GetBookByIsbnAsync_WithInvalidJson_ReturnsNull()
+    {
+        // Arrange
+        var isbn = "23423";
+        var invalidJson = "This is not valid JSON";
+
+        SetupHttpResponse(HttpStatusCode.OK, invalidJson);
+
+        var client = new OpenLibraryClient(_httpClient, _loggerMock.Object);
+
+        // Act
+        var result = await client.GetBookByIsbnAsync(isbn);
+
+        // Assert
+        Assert.That(result, Is.Null);
+    }
+
     private void SetupHttpResponse(HttpStatusCode statusCode, string content)
     {
         var response = new HttpResponseMessage


### PR DESCRIPTION
## Summary
- Adds proper exception handling for JSON parsing errors in OpenLibraryClient
- Catches JsonException when OpenLibrary API returns unexpected response data
- Follows the same error handling pattern as other API clients (TMDB, UPCitemdb)

## Changes
- Added try-catch blocks to `GetBookByIsbnAsync` and `GetReadableBookAsync` methods
- Catches `HttpRequestException`, `JsonException`, and general `Exception` 
- Logs warnings for HTTP/JSON errors with full exception details
- Returns `null` gracefully instead of propagating exceptions
- Added two new tests for invalid JSON handling scenarios

## Test Plan
- [x] All existing OpenLibraryClient tests pass (20/20)
- [x] New tests verify invalid JSON returns null instead of throwing
- [x] Follows AAA pattern and matches existing test structure

## Related Issues
Closes #488

🤖 Generated with [Claude Code](https://claude.com/claude-code)