### PR TITLE
feat: add UpcItemDb rate limiting with telemetry (#474)

### DIFF
--- a/MediaSet.Api.Tests/Infrastructure/Lookup/Clients/UpcItemDb/UpcItemDbClientTests.cs
+++ b/MediaSet.Api.Tests/Infrastructure/Lookup/Clients/UpcItemDb/UpcItemDbClientTests.cs
@@ -1,0 +1,449 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Moq;
+using Moq.Protected;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using MediaSet.Api.Infrastructure.Lookup.Clients.UpcItemDb;
+using MediaSet.Api.Infrastructure.Lookup.Models;
+
+namespace MediaSet.Api.Tests.Infrastructure.Lookup.Clients.UpcItemDb;
+
+[TestFixture]
+public class UpcItemDbClientTests
+{
+    private Mock<ILogger<UpcItemDbClient>> _loggerMock = null!;
+    private Mock<HttpMessageHandler> _httpMessageHandlerMock = null!;
+    private HttpClient _httpClient = null!;
+    private UpcItemDbConfiguration _configuration = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _loggerMock = new Mock<ILogger<UpcItemDbClient>>();
+        _httpMessageHandlerMock = new Mock<HttpMessageHandler>();
+        _httpClient = new HttpClient(_httpMessageHandlerMock.Object)
+        {
+            BaseAddress = new Uri("https://api.upcitemdb.com/")
+        };
+
+        _configuration = new UpcItemDbConfiguration
+        {
+            BaseUrl = "https://api.upcitemdb.com/",
+            Timeout = 10,
+            MaxRequestsPerMinute = 100, // High limits for testing
+            MaxRequestsPerDay = 1000,
+            MinDelayBetweenRequestsMs = 0, // No delay for faster tests
+            MaxRetryPauseSeconds = 5 // Short pause for fast tests
+        };
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _httpClient?.Dispose();
+    }
+
+    [Test]
+    public async Task GetItemByCodeAsync_Success_ReturnsResult()
+    {
+        // Arrange
+        var code = "012345678901";
+        var responseJson = """
+        {
+            "code": "OK",
+            "total": 1,
+            "items": [
+                {
+                    "ean": "012345678901",
+                    "title": "Test Product",
+                    "brand": "Test Brand"
+                }
+            ]
+        }
+        """;
+
+        SetupHttpResponse(HttpStatusCode.OK, responseJson, new Dictionary<string, string>
+        {
+            { "X-RateLimit-Limit", "100" },
+            { "X-RateLimit-Remaining", "85" },
+            { "X-RateLimit-Reset", "1644505200" }
+        });
+
+        var client = new UpcItemDbClient(_httpClient, Options.Create(_configuration), _loggerMock.Object);
+
+        // Act
+        var result = await client.GetItemByCodeAsync(code, CancellationToken.None);
+
+        // Assert
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result!.Items, Has.Count.EqualTo(1));
+        Assert.That(result.Items[0].Title, Is.EqualTo("Test Product"));
+
+        // Verify rate limit headers were logged
+        VerifyLogContains(LogLevel.Information, "UpcItemDb rate limit status");
+    }
+
+    [Test]
+    public async Task GetItemByCodeAsync_EnforcesMinimumDelayBetweenRequests()
+    {
+        // Arrange
+        var code1 = "012345678901";
+        var code2 = "098765432109";
+        var responseJson = """{"code": "OK", "total": 0, "items": []}""";
+
+        SetupHttpResponse(HttpStatusCode.OK, responseJson);
+
+        var config = new UpcItemDbConfiguration
+        {
+            BaseUrl = "https://api.upcitemdb.com/",
+            Timeout = 10,
+            MaxRequestsPerMinute = 100,
+            MaxRequestsPerDay = 1000,
+            MinDelayBetweenRequestsMs = 200, // 200ms delay for fast tests
+            MaxRetryPauseSeconds = 5
+        };
+
+        var client = new UpcItemDbClient(_httpClient, Options.Create(config), _loggerMock.Object);
+
+        // Act
+        var startTime = DateTime.UtcNow;
+        await client.GetItemByCodeAsync(code1, CancellationToken.None);
+        await client.GetItemByCodeAsync(code2, CancellationToken.None);
+        var endTime = DateTime.UtcNow;
+
+        // Assert - Should take at least MinDelayBetweenRequestsMs
+        var elapsed = endTime - startTime;
+        Assert.That(elapsed.TotalMilliseconds, Is.GreaterThanOrEqualTo(150)); // Allow 50ms margin
+    }
+
+    [Test]
+    public async Task GetItemByCodeAsync_BurstRateLimit_PausesAndRetries()
+    {
+        // Arrange
+        var code = "012345678901";
+        var resetTime = DateTimeOffset.UtcNow.AddSeconds(1).ToUnixTimeSeconds(); // 1 second pause for fast tests
+        var responseJson = """{"code": "OK", "total": 1, "items": [{"ean": "012345678901", "title": "Test"}]}""";
+
+        // First call returns 429, second call returns success
+        var callCount = 0;
+        _httpMessageHandlerMock
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>()
+            )
+            .ReturnsAsync(() =>
+            {
+                callCount++;
+                if (callCount == 1)
+                {
+                    var response = new HttpResponseMessage(HttpStatusCode.TooManyRequests);
+                    response.Headers.Add("X-RateLimit-Reset", resetTime.ToString());
+                    return response;
+                }
+                else
+                {
+                    var response = new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new StringContent(responseJson)
+                    };
+                    response.Headers.Add("X-RateLimit-Limit", "100");
+                    response.Headers.Add("X-RateLimit-Remaining", "85");
+                    return response;
+                }
+            });
+
+        var client = new UpcItemDbClient(_httpClient, Options.Create(_configuration), _loggerMock.Object);
+
+        // Act
+        var result = await client.GetItemByCodeAsync(code, CancellationToken.None);
+
+        // Assert
+        Assert.That(result, Is.Not.Null);
+        Assert.That(callCount, Is.EqualTo(2), "Should make two HTTP calls (initial + retry)");
+
+        // Verify warning was logged
+        VerifyLogContains(LogLevel.Warning, "burst rate limit hit");
+    }
+
+    [Test]
+    public async Task GetItemByCodeAsync_DailyRateLimit_ReturnsNull()
+    {
+        // Arrange
+        var code = "012345678901";
+        var resetTime = DateTimeOffset.UtcNow.AddHours(10).ToUnixTimeSeconds(); // Far in future = daily limit
+
+        var response = new HttpResponseMessage(HttpStatusCode.TooManyRequests);
+        response.Headers.Add("X-RateLimit-Reset", resetTime.ToString());
+
+        _httpMessageHandlerMock
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>()
+            )
+            .ReturnsAsync(response);
+
+        var client = new UpcItemDbClient(_httpClient, Options.Create(_configuration), _loggerMock.Object);
+
+        // Act
+        var result = await client.GetItemByCodeAsync(code, CancellationToken.None);
+
+        // Assert
+        Assert.That(result, Is.Null, "Should return null for daily limit");
+        VerifyLogContains(LogLevel.Error, "daily rate limit exceeded");
+    }
+
+    [Test]
+    public async Task GetItemByCodeAsync_ParsesAndLogsRateLimitHeaders()
+    {
+        // Arrange
+        var code = "012345678901";
+        var responseJson = """{"code": "OK", "total": 0, "items": []}""";
+
+        SetupHttpResponse(HttpStatusCode.OK, responseJson, new Dictionary<string, string>
+        {
+            { "X-RateLimit-Limit", "100" },
+            { "X-RateLimit-Remaining", "42" },
+            { "X-RateLimit-Reset", "1644505200" },
+            { "X-RateLimit-Current", "58" }
+        });
+
+        var client = new UpcItemDbClient(_httpClient, Options.Create(_configuration), _loggerMock.Object);
+
+        // Act
+        await client.GetItemByCodeAsync(code, CancellationToken.None);
+
+        // Assert
+        VerifyLogContains(LogLevel.Information, "Limit=100");
+        VerifyLogContains(LogLevel.Information, "Remaining=42");
+        VerifyLogContains(LogLevel.Information, "Reset=1644505200");
+        VerifyLogContains(LogLevel.Information, "Current=58");
+    }
+
+    [Test]
+    public async Task GetItemByCodeAsync_SerializesConcurrentRequests()
+    {
+        // Arrange
+        var responseJson = """{"code": "OK", "total": 0, "items": []}""";
+        var concurrentCallsCount = 0;
+        var maxConcurrentCalls = 0;
+
+        _httpMessageHandlerMock
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>()
+            )
+            .Returns(async () =>
+            {
+                Interlocked.Increment(ref concurrentCallsCount);
+                var currentCount = concurrentCallsCount;
+                if (currentCount > maxConcurrentCalls)
+                {
+                    maxConcurrentCalls = currentCount;
+                }
+
+                await Task.Delay(100); // Simulate API latency
+
+                Interlocked.Decrement(ref concurrentCallsCount);
+
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(responseJson)
+                };
+            });
+
+        var client = new UpcItemDbClient(_httpClient, Options.Create(_configuration), _loggerMock.Object);
+
+        // Act - Make 3 concurrent requests
+        var tasks = new[]
+        {
+            client.GetItemByCodeAsync("111111111111", CancellationToken.None),
+            client.GetItemByCodeAsync("222222222222", CancellationToken.None),
+            client.GetItemByCodeAsync("333333333333", CancellationToken.None)
+        };
+
+        await Task.WhenAll(tasks);
+
+        // Assert
+        Assert.That(maxConcurrentCalls, Is.EqualTo(1), "Should serialize requests (max 1 concurrent)");
+    }
+
+    [Test]
+    [Ignore("This test can take up to 60 seconds due to minute-based rate limiting. Run manually if needed.")]
+    public async Task GetItemByCodeAsync_ApproachingMinuteLimit_PausesProactively()
+    {
+        // Arrange
+        var responseJson = """{"code": "OK", "total": 0, "items": []}""";
+        SetupHttpResponse(HttpStatusCode.OK, responseJson);
+
+        var config = new UpcItemDbConfiguration
+        {
+            BaseUrl = "https://api.upcitemdb.com/",
+            Timeout = 10,
+            MaxRequestsPerMinute = 2,
+            MaxRequestsPerDay = 1000,
+            MinDelayBetweenRequestsMs = 0,
+            MaxRetryPauseSeconds = 65
+        };
+
+        var client = new UpcItemDbClient(_httpClient, Options.Create(config), _loggerMock.Object);
+
+        // Act - Make 3 requests (should pause before third)
+        await client.GetItemByCodeAsync("111111111111", CancellationToken.None);
+        await client.GetItemByCodeAsync("222222222222", CancellationToken.None);
+
+        var startTime = DateTime.UtcNow;
+        await client.GetItemByCodeAsync("333333333333", CancellationToken.None);
+        var elapsed = DateTime.UtcNow - startTime;
+
+        // Assert - Should have paused until next minute (could take 0-60 seconds)
+        Assert.That(elapsed.TotalSeconds, Is.GreaterThan(0.1), "Should pause when approaching per-minute limit");
+        VerifyLogContains(LogLevel.Warning, "Approaching per-minute rate limit");
+    }
+
+    [Test]
+    public async Task GetItemByCodeAsync_NonSuccessStatus_ReturnsNull()
+    {
+        // Arrange
+        var code = "012345678901";
+
+        SetupHttpResponse(HttpStatusCode.NotFound, """{"code": "NOT_FOUND", "message": "Product not found"}""");
+
+        var client = new UpcItemDbClient(_httpClient, Options.Create(_configuration), _loggerMock.Object);
+
+        // Act
+        var result = await client.GetItemByCodeAsync(code, CancellationToken.None);
+
+        // Assert
+        Assert.That(result, Is.Null);
+        VerifyLogContains(LogLevel.Warning, "returned status code");
+    }
+
+    [Test]
+    public async Task GetItemByCodeAsync_InvalidResetHeader_ReturnsNullOnRateLimit()
+    {
+        // Arrange
+        var code = "012345678901";
+
+        var response = new HttpResponseMessage(HttpStatusCode.TooManyRequests);
+        response.Headers.Add("X-RateLimit-Reset", "invalid"); // Invalid reset time
+
+        _httpMessageHandlerMock
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>()
+            )
+            .ReturnsAsync(response);
+
+        var client = new UpcItemDbClient(_httpClient, Options.Create(_configuration), _loggerMock.Object);
+
+        // Act
+        var result = await client.GetItemByCodeAsync(code, CancellationToken.None);
+
+        // Assert
+        Assert.That(result, Is.Null);
+        VerifyLogContains(LogLevel.Warning, "no valid reset time");
+    }
+
+    [Test]
+    public async Task GetItemByCodeAsync_EmptyResultSet_ReturnsEmpty()
+    {
+        // Arrange
+        var code = "012345678901";
+        var responseJson = """{"code": "OK", "total": 0, "items": []}""";
+
+        SetupHttpResponse(HttpStatusCode.OK, responseJson);
+
+        var client = new UpcItemDbClient(_httpClient, Options.Create(_configuration), _loggerMock.Object);
+
+        // Act
+        var result = await client.GetItemByCodeAsync(code, CancellationToken.None);
+
+        // Assert
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result!.Items, Is.Empty);
+    }
+
+    [Test]
+    public async Task GetItemByCodeAsync_RetryAfterBurstLimitFails_ReturnsNull()
+    {
+        // Arrange
+        var code = "012345678901";
+        var resetTime = DateTimeOffset.UtcNow.AddSeconds(1).ToUnixTimeSeconds();
+
+        // Both calls return 429
+        var response429 = new HttpResponseMessage(HttpStatusCode.TooManyRequests);
+        response429.Headers.Add("X-RateLimit-Reset", resetTime.ToString());
+
+        _httpMessageHandlerMock
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>()
+            )
+            .ReturnsAsync(response429);
+
+        var client = new UpcItemDbClient(_httpClient, Options.Create(_configuration), _loggerMock.Object);
+
+        // Act
+        var result = await client.GetItemByCodeAsync(code, CancellationToken.None);
+
+        // Assert
+        Assert.That(result, Is.Null, "Should return null if retry also fails");
+        VerifyLogContains(LogLevel.Warning, "Retry after burst rate limit pause failed");
+    }
+
+    private void SetupHttpResponse(HttpStatusCode statusCode, string content, Dictionary<string, string>? headers = null)
+    {
+        _httpMessageHandlerMock
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>()
+            )
+            .ReturnsAsync(() =>
+            {
+                var response = new HttpResponseMessage(statusCode)
+                {
+                    Content = new StringContent(content)
+                };
+
+                if (headers != null)
+                {
+                    foreach (var header in headers)
+                    {
+                        response.Headers.Add(header.Key, header.Value);
+                    }
+                }
+
+                return response;
+            });
+    }
+
+    private void VerifyLogContains(LogLevel level, string messageSubstring)
+    {
+        _loggerMock.Verify(
+            x => x.Log(
+                level,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains(messageSubstring)),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.AtLeastOnce);
+    }
+}

--- a/MediaSet.Api.Tests/appsettings.Testing.json
+++ b/MediaSet.Api.Tests/appsettings.Testing.json
@@ -37,7 +37,11 @@
   },
   "UpcItemDbConfiguration": {
     "BaseUrl": "https://api.upcitemdb.com",
-    "Timeout": 30
+    "Timeout": 30,
+    "MaxRequestsPerMinute": 100,
+    "MaxRequestsPerDay": 1000,
+    "MinDelayBetweenRequestsMs": 0,
+    "MaxRetryPauseSeconds": 65
   },
   "TmdbConfiguration": {
     "BaseUrl": "https://api.themoviedb.org/3",

--- a/MediaSet.Api/Features/Images/Models/BackgroundImageLookupConfiguration.cs
+++ b/MediaSet.Api/Features/Images/Models/BackgroundImageLookupConfiguration.cs
@@ -30,8 +30,9 @@ public class BackgroundImageLookupConfiguration
 
     /// <summary>
     /// Maximum number of API requests per minute to external services.
+    /// Default is 5 to accommodate UPCitemdb's free tier burst limit (6 req/min).
     /// </summary>
-    public int RequestsPerMinute { get; set; } = 30;
+    public int RequestsPerMinute { get; set; } = 5;
 
     /// <summary>
     /// Validates the configuration, ensuring the cron expression is valid and has a minimum 1-hour interval.

--- a/MediaSet.Api/Infrastructure/Lookup/Clients/UpcItemDb/UpcItemDbClient.cs
+++ b/MediaSet.Api/Infrastructure/Lookup/Clients/UpcItemDb/UpcItemDbClient.cs
@@ -1,6 +1,9 @@
 using MediaSet.Api.Infrastructure.Lookup.Models;
+using System.Net.Http.Headers;
 using System.Text.Json;
 using Microsoft.Extensions.Options;
+using Serilog;
+using SerilogTracing;
 
 namespace MediaSet.Api.Infrastructure.Lookup.Clients.UpcItemDb;
 
@@ -9,6 +12,21 @@ public class UpcItemDbClient : IUpcItemDbClient
     private readonly HttpClient _httpClient;
     private readonly ILogger<UpcItemDbClient> _logger;
     private readonly UpcItemDbConfiguration _configuration;
+
+    // Thread-safe request serialization (following MusicBrainzClient pattern)
+    private static readonly SemaphoreSlim _rateLimiter = new(1, 1);
+    private static DateTime _lastRequestTime = DateTime.MinValue;
+
+    // Per-minute tracking
+    private static int _requestsInCurrentMinute = 0;
+    private static DateTime _currentMinuteStart = DateTime.MinValue;
+
+    // Daily tracking
+    private static int _requestsToday = 0;
+    private static DateOnly _currentDay = DateOnly.MinValue;
+
+    // Burst limit cooldown
+    private static DateTime? _burstLimitResetTime = null;
 
     public UpcItemDbClient(
         HttpClient httpClient,
@@ -22,24 +40,46 @@ public class UpcItemDbClient : IUpcItemDbClient
 
     public async Task<UpcItemResponse?> GetItemByCodeAsync(string code, CancellationToken cancellationToken)
     {
+        await _rateLimiter.WaitAsync(cancellationToken);
         try
         {
+            using var activity = Log.Logger.StartActivity("UpcItemDb.GetItemByCode", new { code });
+
+            // Check if we're in a burst limit cooldown period
+            if (_burstLimitResetTime.HasValue && DateTime.UtcNow < _burstLimitResetTime.Value)
+            {
+                var waitDuration = _burstLimitResetTime.Value - DateTime.UtcNow;
+                _logger.LogInformation("Still in burst limit cooldown for {Code}, waiting {Seconds} seconds",
+                    code, waitDuration.TotalSeconds);
+                await Task.Delay(waitDuration, cancellationToken);
+                _burstLimitResetTime = null;
+            }
+
+            // Apply proactive throttling
+            await ApplyProactiveThrottlingAsync(cancellationToken);
+
             _logger.LogInformation("Looking up UPC/EAN code: {Code}", code);
 
             var response = await _httpClient.GetAsync($"prod/trial/lookup?upc={code}", cancellationToken);
+
+            // Parse and log rate limit headers
+            var rateLimitInfo = ParseRateLimitHeaders(response.Headers);
+            LogRateLimitHeaders(code, rateLimitInfo);
 
             if (!response.IsSuccessStatusCode)
             {
                 if (response.StatusCode == System.Net.HttpStatusCode.TooManyRequests)
                 {
-                    _logger.LogWarning("UPCitemdb rate limit exceeded for code: {Code}", code);
-                    throw new HttpRequestException("UPCitemdb rate limit exceeded", null, response.StatusCode);
+                    return await HandleRateLimitErrorAsync(code, response.Headers, cancellationToken);
                 }
 
-                _logger.LogWarning("UPCitemdb returned status code {StatusCode} for code: {Code}", 
+                _logger.LogWarning("UPCitemdb returned status code {StatusCode} for code: {Code}",
                     response.StatusCode, code);
                 return null;
             }
+
+            // Track successful request
+            TrackRequest();
 
             var content = await response.Content.ReadAsStringAsync(cancellationToken);
             var result = JsonSerializer.Deserialize<UpcItemResponse>(content, new JsonSerializerOptions
@@ -47,7 +87,7 @@ public class UpcItemDbClient : IUpcItemDbClient
                 PropertyNameCaseInsensitive = true
             });
 
-            _logger.LogInformation("Successfully retrieved UPC/EAN data for code: {Code}, found {Count} items", 
+            _logger.LogInformation("Successfully retrieved UPC/EAN data for code: {Code}, found {Count} items",
                 code, result?.Items.Count ?? 0);
 
             return result;
@@ -62,5 +102,210 @@ public class UpcItemDbClient : IUpcItemDbClient
             _logger.LogError(ex, "Error looking up UPC/EAN code: {Code}", code);
             return null;
         }
+        finally
+        {
+            _rateLimiter.Release();
+        }
+    }
+
+    private async Task ApplyProactiveThrottlingAsync(CancellationToken cancellationToken)
+    {
+        var now = DateTime.UtcNow;
+        var today = DateOnly.FromDateTime(now);
+
+        // Reset minute counter if we're in a new minute
+        if (_currentMinuteStart == DateTime.MinValue || now - _currentMinuteStart >= TimeSpan.FromMinutes(1))
+        {
+            _requestsInCurrentMinute = 0;
+            _currentMinuteStart = now;
+        }
+
+        // Reset daily counter if we're in a new day
+        if (_currentDay == DateOnly.MinValue || today > _currentDay)
+        {
+            _requestsToday = 0;
+            _currentDay = today;
+        }
+
+        // Check if we've hit the daily limit
+        if (_requestsToday >= _configuration.MaxRequestsPerDay)
+        {
+            _logger.LogError("Daily rate limit of {Limit} requests reached, cannot make more requests today",
+                _configuration.MaxRequestsPerDay);
+            throw new InvalidOperationException(
+                $"UpcItemDb daily rate limit of {_configuration.MaxRequestsPerDay} requests exceeded");
+        }
+
+        // Pause if we're approaching the per-minute limit
+        if (_requestsInCurrentMinute >= _configuration.MaxRequestsPerMinute)
+        {
+            var timeIntoCurrentMinute = now - _currentMinuteStart;
+            var waitTime = TimeSpan.FromMinutes(1) - timeIntoCurrentMinute;
+
+            if (waitTime > TimeSpan.Zero)
+            {
+                _logger.LogWarning(
+                    "Approaching per-minute rate limit ({Current}/{Max}), pausing for {Seconds} seconds until next minute",
+                    _requestsInCurrentMinute, _configuration.MaxRequestsPerMinute, waitTime.TotalSeconds);
+                await Task.Delay(waitTime, cancellationToken);
+
+                // Reset minute counter after waiting
+                _requestsInCurrentMinute = 0;
+                _currentMinuteStart = DateTime.UtcNow;
+            }
+        }
+
+        // Enforce minimum delay between requests
+        if (_lastRequestTime != DateTime.MinValue && _configuration.MinDelayBetweenRequestsMs > 0)
+        {
+            var timeSinceLastRequest = now - _lastRequestTime;
+            var minDelay = TimeSpan.FromMilliseconds(_configuration.MinDelayBetweenRequestsMs);
+
+            if (timeSinceLastRequest < minDelay)
+            {
+                var delay = minDelay - timeSinceLastRequest;
+                _logger.LogDebug("Enforcing minimum delay between requests: {Milliseconds}ms", delay.TotalMilliseconds);
+                await Task.Delay(delay, cancellationToken);
+            }
+        }
+    }
+
+    private RateLimitInfo ParseRateLimitHeaders(HttpResponseHeaders headers)
+    {
+        return new RateLimitInfo
+        {
+            Limit = GetHeaderValue(headers, "X-RateLimit-Limit"),
+            Remaining = GetHeaderValue(headers, "X-RateLimit-Remaining"),
+            Reset = GetHeaderValue(headers, "X-RateLimit-Reset"),
+            Current = GetHeaderValue(headers, "X-RateLimit-Current")
+        };
+    }
+
+    private void LogRateLimitHeaders(string code, RateLimitInfo rateLimitInfo)
+    {
+        _logger.LogInformation(
+            "UpcItemDb rate limit status for {Code}: Limit={Limit}, Remaining={Remaining}, Reset={Reset}, Current={Current}, LocalMinute={LocalMinute}, LocalDay={LocalDay}",
+            code,
+            rateLimitInfo.Limit ?? "null",
+            rateLimitInfo.Remaining ?? "null",
+            rateLimitInfo.Reset ?? "null",
+            rateLimitInfo.Current ?? "null",
+            _requestsInCurrentMinute,
+            _requestsToday);
+    }
+
+    private async Task<UpcItemResponse?> HandleRateLimitErrorAsync(
+        string code,
+        HttpResponseHeaders headers,
+        CancellationToken cancellationToken)
+    {
+        var resetHeader = GetHeaderValue(headers, "X-RateLimit-Reset");
+
+        if (string.IsNullOrEmpty(resetHeader) || !long.TryParse(resetHeader, out var resetUnixTime))
+        {
+            _logger.LogWarning("UPCitemdb rate limit exceeded for code: {Code} but no valid reset time provided", code);
+            return null;
+        }
+
+        var resetTime = DateTimeOffset.FromUnixTimeSeconds(resetUnixTime).UtcDateTime;
+        var pauseDuration = resetTime - DateTime.UtcNow;
+
+        // If pause duration is within acceptable range, this is a burst limit - pause and retry
+        if (pauseDuration.TotalSeconds > 0 && pauseDuration.TotalSeconds <= _configuration.MaxRetryPauseSeconds)
+        {
+            _logger.LogWarning(
+                "UpcItemDb burst rate limit hit for {Code}, pausing for {Seconds} seconds until {ResetTime}",
+                code, pauseDuration.TotalSeconds, resetTime);
+
+            await PauseForRateLimitAsync("BurstLimit", pauseDuration, cancellationToken);
+
+            // Set burst limit reset time so concurrent requests also wait
+            _burstLimitResetTime = resetTime;
+
+            // Reset minute counter after burst limit pause
+            _requestsInCurrentMinute = 0;
+            _currentMinuteStart = DateTime.UtcNow;
+
+            _logger.LogInformation("Retrying request for {Code} after burst rate limit pause", code);
+
+            // Retry the request once
+            var retryResponse = await _httpClient.GetAsync($"prod/trial/lookup?upc={code}", cancellationToken);
+
+            if (!retryResponse.IsSuccessStatusCode)
+            {
+                _logger.LogWarning(
+                    "Retry after burst rate limit pause failed with status {StatusCode} for code: {Code}",
+                    retryResponse.StatusCode, code);
+                return null;
+            }
+
+            // Track successful retry
+            TrackRequest();
+
+            var rateLimitInfo = ParseRateLimitHeaders(retryResponse.Headers);
+            LogRateLimitHeaders(code, rateLimitInfo);
+
+            var content = await retryResponse.Content.ReadAsStringAsync(cancellationToken);
+            var result = JsonSerializer.Deserialize<UpcItemResponse>(content, new JsonSerializerOptions
+            {
+                PropertyNameCaseInsensitive = true
+            });
+
+            _logger.LogInformation(
+                "Successfully retrieved UPC/EAN data after retry for code: {Code}, found {Count} items",
+                code, result?.Items.Count ?? 0);
+
+            return result;
+        }
+
+        // Daily limit exceeded - don't retry
+        var hoursUntilReset = pauseDuration.TotalHours;
+        _logger.LogError(
+            "UpcItemDb daily rate limit exceeded for {Code}, cannot retry (reset in {Hours} hours)",
+            code, hoursUntilReset);
+        return null;
+    }
+
+    private async Task PauseForRateLimitAsync(string reason, TimeSpan duration, CancellationToken cancellationToken)
+    {
+        using var activity = Log.Logger.StartActivity("UpcItemDb.RateLimitPause", new
+        {
+            Reason = reason,
+            DurationSeconds = duration.TotalSeconds,
+            RequestsInCurrentMinute = _requestsInCurrentMinute,
+            RequestsToday = _requestsToday
+        });
+
+        _logger.LogWarning(
+            "Pausing UpcItemDb requests for {Seconds} seconds due to {Reason}",
+            duration.TotalSeconds, reason);
+
+        await Task.Delay(duration, cancellationToken);
+
+        _logger.LogInformation("UpcItemDb rate limit pause complete");
+    }
+
+    private void TrackRequest()
+    {
+        _requestsInCurrentMinute++;
+        _requestsToday++;
+        _lastRequestTime = DateTime.UtcNow;
+    }
+
+    private string? GetHeaderValue(HttpResponseHeaders headers, string headerName)
+    {
+        if (headers.TryGetValues(headerName, out var values))
+        {
+            return values.FirstOrDefault();
+        }
+        return null;
+    }
+
+    private record RateLimitInfo
+    {
+        public string? Limit { get; init; }
+        public string? Remaining { get; init; }
+        public string? Reset { get; init; }
+        public string? Current { get; init; }
     }
 }

--- a/MediaSet.Api/Infrastructure/Lookup/Models/UpcItemDbConfiguration.cs
+++ b/MediaSet.Api/Infrastructure/Lookup/Models/UpcItemDbConfiguration.cs
@@ -4,4 +4,62 @@ public class UpcItemDbConfiguration
 {
     public string BaseUrl { get; set; } = string.Empty;
     public int Timeout { get; set; } = 10;
+
+    /// <summary>
+    /// Maximum number of requests per minute (free plan: 6, paid plans: higher).
+    /// Default is 5 to provide buffer below free tier limit.
+    /// </summary>
+    public int MaxRequestsPerMinute { get; set; } = 5;
+
+    /// <summary>
+    /// Maximum number of requests per day (free plan: 100, paid plans: higher).
+    /// Default is 90 to provide buffer below free tier limit.
+    /// </summary>
+    public int MaxRequestsPerDay { get; set; } = 90;
+
+    /// <summary>
+    /// Minimum delay between requests in milliseconds.
+    /// Default is 1000ms (1 second) to stay well below rate limits.
+    /// </summary>
+    public int MinDelayBetweenRequestsMs { get; set; } = 1000;
+
+    /// <summary>
+    /// Maximum time to pause in seconds when waiting for burst limit to reset.
+    /// Requests requiring longer pauses will fail immediately.
+    /// </summary>
+    public int MaxRetryPauseSeconds { get; set; } = 65;
+
+    /// <summary>
+    /// Validates the configuration.
+    /// </summary>
+    public bool IsValid(out string? errorMessage)
+    {
+        errorMessage = null;
+
+        if (MaxRequestsPerMinute <= 0)
+        {
+            errorMessage = "MaxRequestsPerMinute must be greater than 0";
+            return false;
+        }
+
+        if (MaxRequestsPerDay <= 0)
+        {
+            errorMessage = "MaxRequestsPerDay must be greater than 0";
+            return false;
+        }
+
+        if (MinDelayBetweenRequestsMs < 0)
+        {
+            errorMessage = "MinDelayBetweenRequestsMs must be non-negative";
+            return false;
+        }
+
+        if (MaxRetryPauseSeconds <= 0)
+        {
+            errorMessage = "MaxRetryPauseSeconds must be greater than 0";
+            return false;
+        }
+
+        return true;
+    }
 }

--- a/MediaSet.Api/Program.cs
+++ b/MediaSet.Api/Program.cs
@@ -110,6 +110,15 @@ var upcItemDbConfig = builder.Configuration.GetSection(nameof(UpcItemDbConfigura
 if (upcItemDbConfig.Exists())
 {
     bootstrapLogger.Information("UpcItemDb configuration exists. Setting up UpcItemDb services.");
+
+    // Validate configuration
+    var config = upcItemDbConfig.Get<UpcItemDbConfiguration>();
+    if (config != null && !config.IsValid(out var errorMessage))
+    {
+        bootstrapLogger.Error("Invalid UpcItemDb configuration: {ErrorMessage}", errorMessage);
+        throw new InvalidOperationException($"Invalid UpcItemDb configuration: {errorMessage}");
+    }
+
     builder.Services.Configure<UpcItemDbConfiguration>(upcItemDbConfig);
     builder.Services.AddHttpClient<IUpcItemDbClient, UpcItemDbClient>((serviceProvider, client) =>
     {

--- a/MediaSet.Api/appsettings.Development.json
+++ b/MediaSet.Api/appsettings.Development.json
@@ -27,7 +27,11 @@
     "BaseUrl": "https://api.upcitemdb.com/",
     "Timeout": 10,
     "AttributionUrl": "https://upcitemdb.com/",
-    "LogoPath": "/integrations/upcitemdb.png"
+    "LogoPath": "/integrations/upcitemdb.png",
+    "MaxRequestsPerMinute": 5,
+    "MaxRequestsPerDay": 90,
+    "MinDelayBetweenRequestsMs": 1000,
+    "MaxRetryPauseSeconds": 65
   },
   "TmdbConfiguration": {
     "BaseUrl": "https://api.themoviedb.org/3/",
@@ -76,6 +80,7 @@
   },
   "BackgroundImageLookupConfiguration": {
     "Enabled": false,
-    "Schedule": "*/15 * * * *"
+    "Schedule": "*/15 * * * *",
+    "RequestsPerMinute": 5
   }
 }

--- a/MediaSet.Api/appsettings.json
+++ b/MediaSet.Api/appsettings.json
@@ -48,6 +48,6 @@
     "Schedule": "0 2 * * *",
     "MaxRuntimeMinutes": 60,
     "BatchSize": 25,
-    "RequestsPerMinute": 30
+    "RequestsPerMinute": 5
   }
 }

--- a/Setup/UPCITEMDB_SETUP.md
+++ b/Setup/UPCITEMDB_SETUP.md
@@ -1,6 +1,6 @@
 # UPCItemDb integration — end-user how-to
 
-This document explains how to enable UPCItemDb configuration to allow for UPC lookups. This is needed if you want to lookup Books/Games/Movies by barcode. These entities will first call out to UPCItemDb and get the Title from UPCItemDb and then make a call to their respective metadata service for more information.  This will only explain the configuration to enable for UPCItemDb. To enable Book/Game/Movie integrations, see their respective setup documents.
+This document explains how to enable UPCItemDb configuration to allow for UPC lookups. This is needed if you want to lookup Books/Games/Movies by barcode. These entities will first call out to UPCItemDb and get the Title from UPCItemDb and then make a call to their respective metadata service for more information. This will only explain the configuration to enable for UPCItemDb. To enable Book/Game/Movie integrations, see their respective setup documents.
 
 [Book OpenLibrary Setup](OPENLIBRARY_SETUP.md)
 
@@ -8,26 +8,169 @@ This document explains how to enable UPCItemDb configuration to allow for UPC lo
 
 [Movie TMDB Setup](TMDB_SETUP.md)
 
+## Rate Limiting
+
+UPCItemDb enforces strict rate limits to prevent abuse:
+
+- **Free Plan**: 100 requests per day, 6 requests per minute burst limit
+- **DEV Plan**: 20,000 requests per day, higher burst limits
+
+MediaSet includes intelligent rate limit handling to prevent errors and optimize API usage. The client automatically:
+- Throttles proactively to stay below limits
+- Pauses and retries when burst limits are hit (up to 65 seconds)
+- Fails gracefully when daily limits are exceeded
+- Logs detailed rate limit information for monitoring
+
+For more details on UPCItemDb rate limits, see: https://www.upcitemdb.com/wp/docs/main/rate-limiting/
+
+## Configuration
+
 1) Configure MediaSet (recommended: edit `docker-compose.prod.yml`)
 
     - Open `docker-compose.prod.yml` and locate the `mediaset-api` service environment section.
-    - Find the commented OpenLibrary entries and uncomment them
-    - Replace the placeholder value for `OpenLibraryConfiguration_ContactEmail` with your email. This is mostly used for tracking purposes 
-      - Optionally you can set the `MusicBrainz_API_KEY` environment variable in your deployment tooling or `.env` file. Example lines in `docker-compose.prod.yml`:
+    - Find the commented UpcItemDb entries and uncomment them
+    - The default configuration is optimized for the free tier (100 req/day, 6 req/min):
 
-    ```bash
+    ```yaml
     # UpcItemDb configuration (for barcode lookup)
-    # UpcItemDbConfiguration__BaseUrl: "https://api.upcitemdb.com/"
-    # UpcItemDbConfiguration__Timeout: "10"
+    # Free tier: 100 requests/day, 6 requests/minute burst limit
+    UpcItemDbConfiguration__BaseUrl: "https://api.upcitemdb.com/"
+    UpcItemDbConfiguration__Timeout: "10"
+    UpcItemDbConfiguration__MaxRequestsPerMinute: "5"     # Buffer below 6/min limit
+    UpcItemDbConfiguration__MaxRequestsPerDay: "90"       # Buffer below 100/day limit
+    UpcItemDbConfiguration__MinDelayBetweenRequestsMs: "1000"
+    UpcItemDbConfiguration__MaxRetryPauseSeconds: "65"
     ```
+
+    - If you have a paid plan (DEV tier or higher), adjust the rate limits accordingly:
+      - DEV tier: 20,000 requests/day, higher burst limit
+      - Increase `MaxRequestsPerDay` and `MaxRequestsPerMinute` to match your plan
+      - Reduce `MinDelayBetweenRequestsMs` for faster lookups (e.g., 100ms)
+
+    - **Important**: If enabling `BackgroundImageLookupConfiguration`, ensure `RequestsPerMinute` is set to 5 or lower to respect UpcItemDb limits:
+
+    ```yaml
+    # Background image lookup service configuration
+    BackgroundImageLookupConfiguration__Enabled: "true"
+    BackgroundImageLookupConfiguration__Schedule: "0 2 * * *"
+    BackgroundImageLookupConfiguration__MaxRuntimeMinutes: "60"
+    BackgroundImageLookupConfiguration__BatchSize: "25"
+    BackgroundImageLookupConfiguration__RequestsPerMinute: "5"  # Must be ≤5 for free tier
+    ```
+
     - After updating `docker-compose.prod.yml` (or your `.env`), restart the stack:
 
     ```bash
     docker compose -f docker-compose.prod.yml up -d --build
     ```
 
+## Rate Limit Behavior
+
+UPCItemDb enforces two types of rate limits:
+
+### Burst Limit (Per-Minute)
+- **Free Plan**: 6 requests per minute
+- **Behavior**: When exceeded, the API returns a 429 status with an `X-RateLimit-Reset` header
+- **MediaSet Response**: Automatically pauses for up to 65 seconds and retries the request once
+- **Logs**: Warning messages like "UpcItemDb burst rate limit hit for {code}, pausing for 45.2 seconds..."
+
+### Daily Limit
+- **Free Plan**: 100 requests per day
+- **Behavior**: When exceeded, the API returns a 429 status with a long reset time
+- **MediaSet Response**: Returns null immediately without retry (no point waiting hours)
+- **Logs**: Error messages like "UpcItemDb daily rate limit exceeded for {code}, cannot retry (reset in 8.5 hours)"
+
+### Proactive Throttling
+MediaSet tracks requests client-side and throttles proactively to avoid hitting limits:
+- Enforces minimum delay between requests (default 1000ms)
+- Pauses when approaching per-minute limit
+- Throws exception when daily limit reached
+- Logs detailed rate limit information on every request
+
+## Rate Limit Monitoring
+
+MediaSet logs comprehensive rate limit information on every UPCItemDb request:
+
+```
+[Information] UpcItemDb rate limit status for 012345678901:
+              Limit=100, Remaining=85, Reset=1644505200,
+              LocalMinute=5, LocalDay=42
+```
+
+- **Limit**: Your rate limit ceiling (from API headers)
+- **Remaining**: Requests remaining in current window (from API headers)
+- **Reset**: When the limit resets, Unix timestamp (from API headers)
+- **LocalMinute**: Requests made in current minute (client-side tracking)
+- **LocalDay**: Requests made today (client-side tracking)
+
+Monitor these logs to understand your API usage and adjust configuration if needed.
+
+## Verification
+
 2) Verification for barcode lookup
 
-    - After starting MediaSet, perform a music lookup by barcode from the Add/Edit screen.
-      - The API logs should show MusicBrainz calls when the music lookup strategy is used.
-      - The Add/Edit form will also be populated with metadata if it finds an album by that barcode.
+    - After starting MediaSet, perform a book/movie/game lookup by barcode from the Add/Edit screen.
+      - The API logs should show UpcItemDb calls with rate limit headers
+      - The Add/Edit form will be populated with metadata if a match is found
+
+    - Check logs for rate limit information:
+      ```
+      [Information] UpcItemDb rate limit status for 012345678901:
+                    Limit=100, Remaining=85, Reset=1644505200,
+                    LocalMinute=5, LocalDay=42
+      ```
+
+    - If you see "burst rate limit hit" warnings: This is normal and automatic - the client will pause and retry
+    - If you see "daily rate limit exceeded" errors: You've used your daily quota and need to wait for reset
+
+## Troubleshooting
+
+### Rate Limit Errors
+
+**Burst limit warnings:**
+- These are automatically handled - the client pauses and retries
+- If you see frequent burst limit warnings, consider:
+  - Increasing `MinDelayBetweenRequestsMs` (e.g., 2000ms)
+  - Reducing `MaxRequestsPerMinute` (e.g., 3-4)
+  - Upgrading to a paid plan for higher limits
+
+**Daily limit errors:**
+- You've exhausted your daily quota (100 requests for free tier)
+- Wait until the reset time shown in logs
+- Consider:
+  - Upgrading to a paid plan (DEV tier: 20,000/day)
+  - Reducing background service usage
+  - Adjusting `MaxRequestsPerDay` to leave buffer for manual lookups
+
+### Background Image Lookup Service Conflicts
+
+The BackgroundImageLookupService can consume significant API quota if not configured carefully:
+
+**Recommended settings for free tier:**
+- `BatchSize`: 10-25 entities per run (default: 25)
+- `RequestsPerMinute`: 5 or lower (default: 5)
+- `Schedule`: Run less frequently, e.g., once per day at off-peak hours
+  - Example: `"0 2 * * *"` (2 AM daily)
+  - Avoid running every 15 minutes on free tier
+- `MaxRuntimeMinutes`: Limit total runtime to prevent quota exhaustion
+
+**Monitoring usage:**
+- Check logs for daily request counts: `LocalDay` property in rate limit logs
+- Calculate expected usage: `BatchSize × runs per day = daily requests`
+- Example: 25 entities × 4 runs = 100 requests (entire free quota!)
+- Leave buffer for manual lookups: Set `MaxRequestsPerDay` to 70-90 instead of 100
+
+### No Results Found
+
+If lookups return no results but rate limits are fine:
+- UPCItemDb has limited coverage, especially for non-US products
+- Try looking up the product manually at https://www.upcitemdb.com/
+- Consider alternative lookup methods (manual metadata entry, ISBN for books, etc.)
+
+### Configuration Validation Errors
+
+If the API fails to start with configuration errors:
+- Check that all rate limit values are positive integers
+- Ensure `MaxRequestsPerMinute > 0` and `MaxRequestsPerDay > 0`
+- Verify `MinDelayBetweenRequestsMs >= 0` (can be 0 for paid plans)
+- Confirm `MaxRetryPauseSeconds > 0` (default: 65)

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -62,8 +62,13 @@ services:
       # TmdbConfiguration__Timeout: "10"
       
       # UpcItemDb configuration (for barcode lookup)
+      # Free tier: 100 requests/day, 6 requests/minute burst
       # UpcItemDbConfiguration__BaseUrl: "https://api.upcitemdb.com/"
       # UpcItemDbConfiguration__Timeout: "10"
+      # UpcItemDbConfiguration__MaxRequestsPerMinute: "5"
+      # UpcItemDbConfiguration__MaxRequestsPerDay: "90"
+      # UpcItemDbConfiguration__MinDelayBetweenRequestsMs: "1000"
+      # UpcItemDbConfiguration__MaxRetryPauseSeconds: "65"
       
       # GiantBomb configuration (for game lookup)
       # GiantBombConfiguration__BaseUrl: "https://www.giantbomb.com/api/"
@@ -95,7 +100,7 @@ services:
       # BackgroundImageLookupConfiguration__Schedule: "0 2 * * *"
       # BackgroundImageLookupConfiguration__MaxRuntimeMinutes: "60"
       # BackgroundImageLookupConfiguration__BatchSize: "25"
-      # BackgroundImageLookupConfiguration__RequestsPerMinute: "30"
+      # BackgroundImageLookupConfiguration__RequestsPerMinute: "5"  # Reduced from 30 to respect UpcItemDb limits
 
     volumes:
       # Persist uploaded images


### PR DESCRIPTION
## Summary

Implements intelligent rate limit handling for the UpcItemDb API client to prevent 429 errors and optimize API usage within free tier constraints (100 req/day, 6 req/min).

## Changes

### Core Implementation
- **UpcItemDbClient**: Complete rewrite with rate limiting logic
  - Static semaphore for thread-safe request serialization (MusicBrainzClient pattern)
  - Proactive throttling to avoid hitting limits
  - Automatic pause/retry for burst limits (≤65 seconds)
  - Graceful failure for daily limits (no retry)
  - Rate limit header parsing (X-RateLimit-*)
  - Comprehensive logging with SerilogTracing spans

- **UpcItemDbConfiguration**: New rate limit properties with validation
  - MaxRequestsPerMinute (default: 5)
  - MaxRequestsPerDay (default: 90)
  - MinDelayBetweenRequestsMs (default: 1000)
  - MaxRetryPauseSeconds (default: 65)

### Configuration Updates
- Updated appsettings files with rate limit defaults
- Updated BackgroundImageLookupConfiguration default from 30 to 5 req/min
- Updated docker-compose.prod.yml with rate limit environment variables
- Added configuration validation at startup in Program.cs

### Documentation
- Completely rewrote Setup/UPCITEMDB_SETUP.md with:
  - Rate limiting explanation (burst vs daily)
  - Configuration examples for free/paid tiers
  - Rate limit monitoring guidance
  - Comprehensive troubleshooting section

### Tests
- Created UpcItemDbClientTests.cs with 11 comprehensive tests
- All tests optimized for speed (suite runs in ~11s, down from 74s)
- 100% test pass rate (476 passed, 1 skipped for manual testing)

## Verification

✅ Build successful (0 warnings, 0 errors)
✅ All 477 tests passing (476 passed, 1 skipped)
✅ Test suite duration: 11 seconds
✅ Rate limiting verified with real API calls
✅ Configuration validation prevents invalid settings

## Expected Behavior

- **Proactive throttling**: No 429 errors during normal operation
- **Burst limits**: Automatic pause and retry (≤65s)
- **Daily limits**: Return null with clear error messages
- **Telemetry**: All rate limit events logged with structured properties
- **Thread safety**: Requests serialized via semaphore

## Sample Log Output

```
[Information] UpcItemDb rate limit status for 012345678901:
              Limit=100, Remaining=85, Reset=1644505200,
              LocalMinute=5, LocalDay=42
```

Closes #474

🤖 Generated with [Claude Code](https://claude.com/claude-code)