### PR TITLE
fix(analysis): update naming rule to allow underscore prefix on private fields

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -171,9 +171,9 @@ dotnet_naming_rule.non_field_members_should_be_pascal_case.severity = error
 dotnet_naming_rule.non_field_members_should_be_pascal_case.symbols = non_field_members
 dotnet_naming_rule.non_field_members_should_be_pascal_case.style = pascal_case
 
-dotnet_naming_rule.private_or_internal_field_should_be_camel_case.severity = error
-dotnet_naming_rule.private_or_internal_field_should_be_camel_case.symbols = private_or_internal_field
-dotnet_naming_rule.private_or_internal_field_should_be_camel_case.style = camel_case
+dotnet_naming_rule.private_or_internal_field_should_be_underscore_camel_case.severity = error
+dotnet_naming_rule.private_or_internal_field_should_be_underscore_camel_case.symbols = private_or_internal_field
+dotnet_naming_rule.private_or_internal_field_should_be_underscore_camel_case.style = underscore_camel_case
 
 # Symbol specifications
 dotnet_naming_symbols.interface.applicable_kinds = interface
@@ -203,10 +203,15 @@ dotnet_naming_style.prefixed_with_i.required_suffix =
 dotnet_naming_style.prefixed_with_i.word_separator = 
 dotnet_naming_style.prefixed_with_i.capitalization = pascal_case
 
-dotnet_naming_style.camel_case.required_prefix = 
-dotnet_naming_style.camel_case.required_suffix = 
-dotnet_naming_style.camel_case.word_separator = 
+dotnet_naming_style.camel_case.required_prefix =
+dotnet_naming_style.camel_case.required_suffix =
+dotnet_naming_style.camel_case.word_separator =
 dotnet_naming_style.camel_case.capitalization = camel_case
+
+dotnet_naming_style.underscore_camel_case.required_prefix = _
+dotnet_naming_style.underscore_camel_case.required_suffix =
+dotnet_naming_style.underscore_camel_case.word_separator =
+dotnet_naming_style.underscore_camel_case.capitalization = camel_case
 
 # Code analysis rules (CA)
 dotnet_diagnostic.CA1062.severity = none  # Validate arguments of public methods


### PR DESCRIPTION
## Summary
- Adds `underscore_camel_case` naming style with `required_prefix = _` to `.editorconfig`
- Updates the private/internal field naming rule to use the new style, matching the project's `_camelCase` convention
- Resolves IDE1006 errors in VS Code for fields like `_logger`, `_client`

Closes #497

## Test plan
- [x] Verify `dotnet build` passes with 0 warnings/errors
- [x] Verify VS Code no longer shows IDE1006 for underscore-prefixed private fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)