### PR TITLE
fix(lookup): improve movie title cleaning with brand removal and truncation closes #494

### DIFF
--- a/MediaSet.Api.Tests/Infrastructure/Lookup/Strategies/MovieLookupStrategyTests.cs
+++ b/MediaSet.Api.Tests/Infrastructure/Lookup/Strategies/MovieLookupStrategyTests.cs
@@ -444,6 +444,33 @@ public class MovieLookupStrategyTests
         await TestTitleCleaning(upc, rawTitle, expectedCleanTitle);
     }
 
+    [Test]
+    public async Task LookupAsync_CleansMovieTitleCorrectly_RemovesCommaEditionInfo()
+    {
+        var upc = "043396471238";
+        var rawTitle = "Batman Begins, Two Disc Deluxe Edition, Hologram Cover (DVD, 2005)";
+        var expectedCleanTitle = "Batman Begins";
+        await TestTitleCleaning(upc, rawTitle, expectedCleanTitle);
+    }
+
+    [Test]
+    public async Task LookupAsync_CleansMovieTitleCorrectly_RemovesDiscEditionAndFormatCombo()
+    {
+        var upc = "043396471238";
+        var rawTitle = "Bambi Two-Disc Diamond Edition Blue-Ray + DVD";
+        var expectedCleanTitle = "Bambi";
+        await TestTitleCleaning(upc, rawTitle, expectedCleanTitle);
+    }
+
+    [Test]
+    public async Task LookupAsync_CleansMovieTitleCorrectly_RemovesCompleteCollection()
+    {
+        var upc = "043396471238";
+        var rawTitle = "Berserk: Season 1 Complete Collection";
+        var expectedCleanTitle = "Berserk: Season 1";
+        await TestTitleCleaning(upc, rawTitle, expectedCleanTitle);
+    }
+
     private async Task TestTitleCleaning(string upc, string rawTitle, string expectedCleanTitle, string brand = "Studio")
     {
         var upcResponse = CreateUpcItemResponse(upc, rawTitle, brand);

--- a/MediaSet.Api/Infrastructure/Lookup/Strategies/MovieLookupStrategy.cs
+++ b/MediaSet.Api/Infrastructure/Lookup/Strategies/MovieLookupStrategy.cs
@@ -148,6 +148,12 @@ public class MovieLookupStrategy : ILookupStrategy<MovieResponse>
             title = title[..bracketIndex];
         }
 
+        // Truncate at comma followed by disc-count keywords (e.g., ", Two Disc Deluxe Edition, Hologram Cover")
+        title = System.Text.RegularExpressions.Regex.Replace(title, @",\s+(?:\d+|Two|Three|Four|Five|Six)\s+Discs?\b.*$", string.Empty, System.Text.RegularExpressions.RegexOptions.IgnoreCase);
+
+        // Remove format combinations with + (e.g., "Blue-Ray + DVD", "Blu-ray + Digital")
+        title = System.Text.RegularExpressions.Regex.Replace(title, @"\s*(Blu-?ray|Blue-?ray|DVD|4K|BD|UHD|Digital|HD)\s*\+\s*(Blu-?ray|Blue-?ray|DVD|4K|BD|UHD|Digital|HD).*$", string.Empty, System.Text.RegularExpressions.RegexOptions.IgnoreCase);
+
         // Remove trailing brand text
         if (!string.IsNullOrWhiteSpace(brand))
         {
@@ -158,7 +164,13 @@ public class MovieLookupStrategy : ILookupStrategy<MovieResponse>
         title = System.Text.RegularExpressions.Regex.Replace(title, @"\s*-\s*(DVD|Blu-?ray|4K|BD|UHD|Digital|HD|DIGITAL VIDEO DISC).*$", string.Empty, System.Text.RegularExpressions.RegexOptions.IgnoreCase);
 
         // Remove format keywords at end (e.g., 'DVD', 'Blu-ray', etc.)
-        title = System.Text.RegularExpressions.Regex.Replace(title, @"\s*(DVD|Blu-?ray|4K|BD|UHD|Digital|HD)\s*$", string.Empty, System.Text.RegularExpressions.RegexOptions.IgnoreCase);
+        title = System.Text.RegularExpressions.Regex.Replace(title, @"\s*(DVD|Blu-?ray|Blue-?ray|4K|BD|UHD|Digital|HD)\s*$", string.Empty, System.Text.RegularExpressions.RegexOptions.IgnoreCase);
+
+        // Remove trailing disc-count edition phrases (e.g., "Two-Disc Diamond Edition")
+        title = System.Text.RegularExpressions.Regex.Replace(title, @"\s+(?:\d+-?Discs?|Two-?Discs?|Three-?Discs?|Four-?Discs?|Five-?Discs?|Six-?Discs?)\b.*$", string.Empty, System.Text.RegularExpressions.RegexOptions.IgnoreCase);
+
+        // Remove trailing "Complete Collection"
+        title = System.Text.RegularExpressions.Regex.Replace(title, @"\s+Complete\s+Collection\s*$", string.Empty, System.Text.RegularExpressions.RegexOptions.IgnoreCase);
 
         // Clean up multiple spaces and trim
         title = System.Text.RegularExpressions.Regex.Replace(title, @"\s+", " ").Trim();


### PR DESCRIPTION
## Summary
- Use UPC `Brand` field to strip studio name prefixes (e.g., `Paramount - Beverly Hills Cop`) and trailing brand text
- Replace bracket/paren content-removal regexes with truncation at first `(`/`[`, which also eliminates trailing junk (studio names, genre words, director credits)
- Handle edge cases: comma-separated edition info, format combos with `+`, disc-count edition phrases, and "Complete Collection" suffixes

## Test plan
- [x] All 47 `MovieLookupStrategyTests` pass (15 new test cases added)
- [x] Verify title cleaning with real UPC lookups for movies with noisy titles

🤖 Generated with [Claude Code](https://claude.com/claude-code)