### PR TITLE
fix(ui): replace button overlay with div in select inputs

### DIFF
--- a/MediaSet.Remix/app/components/multiselect-input.tsx
+++ b/MediaSet.Remix/app/components/multiselect-input.tsx
@@ -157,9 +157,8 @@ export default function MultiselectInput(props: MultiselectProps) {
   return (
     <>
       {/* click-away overlay */}
-      <button
-        type="button"
-        aria-label="Close dropdown"
+      <div
+        aria-hidden="true"
         className={`absolute top-0 left-0 z-10 w-full h-full ${displayOptions ? '' : 'hidden'}`}
         onMouseDown={() => setDisplayOptions(false)}
       />

--- a/MediaSet.Remix/app/components/singleselect-input.tsx
+++ b/MediaSet.Remix/app/components/singleselect-input.tsx
@@ -157,9 +157,8 @@ export default function SingleselectInput(props: SingleselectProps) {
   return (
     <>
       {/* click-away overlay */}
-      <button
-        type="button"
-        aria-label="Close dropdown"
+      <div
+        aria-hidden="true"
         className={`absolute top-0 left-0 z-10 w-full h-full ${displayOptions ? '' : 'hidden'}`}
         onMouseDown={() => setDisplayOptions(false)}
       />


### PR DESCRIPTION
## Summary

- Fixes #514
- Replaces the `<button>` click-away overlay with an `<div aria-hidden="true">` in both `singleselect-input.tsx` and `multiselect-input.tsx`
- The `<button>` element was causing browsers to render a full-page interactive button when the dropdown was open; a plain `<div>` is visually transparent and captures mouse events without browser button semantics

## Test plan

- [x] Open an Add/Edit form with a single-select dropdown (e.g. Format field) and verify the dropdown shows a list of items, not a full-page button
- [x] Open an Add/Edit form with a multi-select dropdown and verify the same
- [x] Verify clicking outside the open dropdown still closes it
- [x] Verify keyboard navigation (Arrow keys, Enter, Escape, Tab) still works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)