### PR TITLE
fix(ui): display music duration in MM:SS format

### DIFF
--- a/MediaSet.Remix/app/routes/$entity.$entityId/components/music.tsx
+++ b/MediaSet.Remix/app/routes/$entity.$entityId/components/music.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import DeleteDialog from '~/components/delete-dialog';
 import ImageDisplay from '~/components/image-display';
 import { MusicEntity, Entity } from '~/models';
+import { millisecondsToMinutesSeconds } from '~/utils/helpers';
 
 type MusicProps = {
   music: MusicEntity;
@@ -83,7 +84,7 @@ export default function Music({ music, apiUrl }: MusicProps) {
                 Duration
               </label>
               <div id="duration" className="grow">
-                {music.duration} minutes
+                {millisecondsToMinutesSeconds(music.duration)}
               </div>
             </div>
             <div className="flex flex-col md:flex-row mb-2 md:mb-0">
@@ -135,7 +136,7 @@ export default function Music({ music, apiUrl }: MusicProps) {
                         <tr key={index} className="border-b border-gray-700">
                           <td className="py-1 px-2">{disc.trackNumber}</td>
                           <td className="py-1 px-2">{disc.title}</td>
-                          <td className="py-1 px-2">{disc.duration}</td>
+                          <td className="py-1 px-2">{millisecondsToMinutesSeconds(disc.duration)}</td>
                         </tr>
                       ))}
                     </tbody>


### PR DESCRIPTION
## Summary
- Converts raw millisecond values to MM:SS format on the music detail page
- Fixes album-level duration display (was showing e.g. `2055000 minutes` instead of `34:15`)
- Fixes per-track duration display in the disc list table
- Reuses the existing `millisecondsToMinutesSeconds` helper already used by the edit form

Closes #516

## Test plan
- [x] Open a music detail page and verify the Duration field shows MM:SS (e.g. `34:15`) instead of raw milliseconds
- [x] Verify disc list track durations also show MM:SS format
- [x] Verify the edit form still shows durations correctly (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)