### PR TITLE
feat(ui): sortable entity list columns with dynamic API ordering

### DIFF
--- a/MediaSet.Api.Tests/Infrastructure/DataAccess/EntityServiceTests.cs
+++ b/MediaSet.Api.Tests/Infrastructure/DataAccess/EntityServiceTests.cs
@@ -291,18 +291,8 @@ namespace MediaSet.Api.Tests.Infrastructure.DataAccess
             Assert.That(result, Is.Null);
         }
 
-        [Test]
-        public async Task SearchAsync_ShouldReturnMatchingEntities_WhenSearchTextMatches()
+        private Mock<IAsyncCursor<Book>> SetupCursorWithBooks(List<Book> books)
         {
-            // Arrange
-            var searchText = "fantasy";
-            var orderBy = "title:asc";
-            var books = new List<Book>
-            {
-                _bookFaker.Clone().RuleFor(b => b.Title, "Fantasy Adventure").Generate(),
-                _bookFaker.Clone().RuleFor(b => b.Title, "Epic Fantasy").Generate()
-            };
-
             var asyncCursor = new Mock<IAsyncCursor<Book>>();
             asyncCursor.Setup(c => c.Current).Returns(books);
             asyncCursor.SetupSequence(c => c.MoveNext(It.IsAny<CancellationToken>()))
@@ -311,15 +301,27 @@ namespace MediaSet.Api.Tests.Infrastructure.DataAccess
             asyncCursor.SetupSequence(c => c.MoveNextAsync(It.IsAny<CancellationToken>()))
                 .ReturnsAsync(true)
                 .ReturnsAsync(false);
+            return asyncCursor;
+        }
+
+        [Test]
+        public async Task SearchAsync_ShouldReturnMatchingEntities_WhenSearchTextMatches()
+        {
+            // Arrange
+            var books = new List<Book>
+            {
+                _bookFaker.Clone().RuleFor(b => b.Title, "Fantasy Adventure").Generate(),
+                _bookFaker.Clone().RuleFor(b => b.Title, "Epic Fantasy").Generate()
+            };
 
             _collectionMock.Setup(c => c.FindAsync(
                 It.IsAny<FilterDefinition<Book>>(),
                 It.IsAny<FindOptions<Book, Book>>(),
                 It.IsAny<CancellationToken>()))
-                .ReturnsAsync(asyncCursor.Object);
+                .ReturnsAsync(SetupCursorWithBooks(books).Object);
 
             // Act
-            var result = await _entityService.SearchAsync(searchText, orderBy);
+            var result = await _entityService.SearchAsync("fantasy", "title:asc");
 
             // Assert
             Assert.That(result, Is.Not.Null);
@@ -334,96 +336,104 @@ namespace MediaSet.Api.Tests.Infrastructure.DataAccess
         public async Task SearchAsync_ShouldReturnEmpty_WhenNoMatchesFound()
         {
             // Arrange
-            var searchText = "nonexistent";
-            var orderBy = "title:asc";
-            var emptyList = new List<Book>();
-
-            var asyncCursor = new Mock<IAsyncCursor<Book>>();
-            asyncCursor.Setup(c => c.Current).Returns(emptyList);
-            asyncCursor.SetupSequence(c => c.MoveNext(It.IsAny<CancellationToken>()))
-                .Returns(true)
-                .Returns(false);
-            asyncCursor.SetupSequence(c => c.MoveNextAsync(It.IsAny<CancellationToken>()))
-                .ReturnsAsync(true)
-                .ReturnsAsync(false);
-
             _collectionMock.Setup(c => c.FindAsync(
                 It.IsAny<FilterDefinition<Book>>(),
                 It.IsAny<FindOptions<Book, Book>>(),
                 It.IsAny<CancellationToken>()))
-                .ReturnsAsync(asyncCursor.Object);
+                .ReturnsAsync(SetupCursorWithBooks([]).Object);
 
             // Act
-            var result = await _entityService.SearchAsync(searchText, orderBy);
+            var result = await _entityService.SearchAsync("nonexistent", "title:asc");
 
             // Assert
             Assert.That(result, Is.Empty);
         }
 
         [Test]
-        public async Task SearchAsync_ShouldHandleAscendingOrder()
+        public async Task SearchAsync_ShouldAcceptValidField_WhenOrderByFieldExists()
         {
             // Arrange
-            var searchText = "book";
-            var orderBy = "title:asc";
             var books = new List<Book>
             {
                 _bookFaker.Clone().RuleFor(b => b.Title, "Book A").Generate(),
                 _bookFaker.Clone().RuleFor(b => b.Title, "Book B").Generate()
             };
 
-            var asyncCursor = new Mock<IAsyncCursor<Book>>();
-            asyncCursor.Setup(c => c.Current).Returns(books);
-            asyncCursor.SetupSequence(c => c.MoveNext(It.IsAny<CancellationToken>()))
-                .Returns(true)
-                .Returns(false);
-            asyncCursor.SetupSequence(c => c.MoveNextAsync(It.IsAny<CancellationToken>()))
-                .ReturnsAsync(true)
-                .ReturnsAsync(false);
+            _collectionMock.Setup(c => c.FindAsync(
+                It.IsAny<FilterDefinition<Book>>(),
+                It.IsAny<FindOptions<Book, Book>>(),
+                It.IsAny<CancellationToken>()))
+                .ReturnsAsync(SetupCursorWithBooks(books).Object);
+
+            // Act — sorting by "format" which is a valid Book field
+            var result = await _entityService.SearchAsync("book", "format:asc");
+
+            // Assert
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result.Count(), Is.EqualTo(2));
+        }
+
+        [Test]
+        public async Task SearchAsync_ShouldAcceptFieldNameCaseInsensitively()
+        {
+            // Arrange
+            var books = new List<Book>
+            {
+                _bookFaker.Clone().RuleFor(b => b.Title, "Book A").Generate()
+            };
 
             _collectionMock.Setup(c => c.FindAsync(
                 It.IsAny<FilterDefinition<Book>>(),
                 It.IsAny<FindOptions<Book, Book>>(),
                 It.IsAny<CancellationToken>()))
-                .ReturnsAsync(asyncCursor.Object);
+                .ReturnsAsync(SetupCursorWithBooks(books).Object);
 
-            // Act
-            var result = await _entityService.SearchAsync(searchText, orderBy);
+            // Act — "TITLE" should match the "Title" property case-insensitively
+            var result = await _entityService.SearchAsync("book", "TITLE:asc");
 
             // Assert
             Assert.That(result, Is.Not.Null);
-            Assert.That(result.Count(), Is.EqualTo(2));
+            Assert.That(result.Count(), Is.EqualTo(1));
+        }
+
+        [Test]
+        public void SearchAsync_ShouldThrowArgumentException_WhenOrderByFieldIsInvalid()
+        {
+            // Arrange & Act & Assert
+            Assert.ThrowsAsync<ArgumentException>(
+                async () => await _entityService.SearchAsync("book", "nonExistentField:asc"));
+        }
+
+        [Test]
+        public void SearchAsync_ShouldThrowArgumentException_WithDescriptiveMessage_WhenOrderByFieldIsInvalid()
+        {
+            // Arrange & Act
+            var ex = Assert.ThrowsAsync<ArgumentException>(
+                async () => await _entityService.SearchAsync("book", "invalidField:asc"));
+
+            // Assert
+            Assert.That(ex!.Message, Does.Contain("invalidField"));
+            Assert.That(ex.Message, Does.Contain("Book"));
         }
 
         [Test]
         public async Task SearchAsync_ShouldHandleDescendingOrder()
         {
             // Arrange
-            var searchText = "book";
-            var orderBy = "title:desc";
             var books = new List<Book>
             {
                 _bookFaker.Clone().RuleFor(b => b.Title, "Book B").Generate(),
                 _bookFaker.Clone().RuleFor(b => b.Title, "Book A").Generate()
             };
 
-            var asyncCursor = new Mock<IAsyncCursor<Book>>();
-            asyncCursor.Setup(c => c.Current).Returns(books);
-            asyncCursor.SetupSequence(c => c.MoveNext(It.IsAny<CancellationToken>()))
-                .Returns(true)
-                .Returns(false);
-            asyncCursor.SetupSequence(c => c.MoveNextAsync(It.IsAny<CancellationToken>()))
-                .ReturnsAsync(true)
-                .ReturnsAsync(false);
-
             _collectionMock.Setup(c => c.FindAsync(
                 It.IsAny<FilterDefinition<Book>>(),
                 It.IsAny<FindOptions<Book, Book>>(),
                 It.IsAny<CancellationToken>()))
-                .ReturnsAsync(asyncCursor.Object);
+                .ReturnsAsync(SetupCursorWithBooks(books).Object);
 
             // Act
-            var result = await _entityService.SearchAsync(searchText, orderBy);
+            var result = await _entityService.SearchAsync("book", "title:desc");
 
             // Assert
             Assert.That(result, Is.Not.Null);
@@ -431,33 +441,22 @@ namespace MediaSet.Api.Tests.Infrastructure.DataAccess
         }
 
         [Test]
-        public async Task SearchAsync_ShouldDefaultToAscending_WhenOrderByIsEmpty()
+        public async Task SearchAsync_ShouldDefaultToTitleAscending_WhenOrderByIsEmpty()
         {
             // Arrange
-            var searchText = "book";
-            var orderBy = "";
             var books = new List<Book>
             {
                 _bookFaker.Clone().RuleFor(b => b.Title, "Book Title").Generate()
             };
 
-            var asyncCursor = new Mock<IAsyncCursor<Book>>();
-            asyncCursor.Setup(c => c.Current).Returns(books);
-            asyncCursor.SetupSequence(c => c.MoveNext(It.IsAny<CancellationToken>()))
-                .Returns(true)
-                .Returns(false);
-            asyncCursor.SetupSequence(c => c.MoveNextAsync(It.IsAny<CancellationToken>()))
-                .ReturnsAsync(true)
-                .ReturnsAsync(false);
-
             _collectionMock.Setup(c => c.FindAsync(
                 It.IsAny<FilterDefinition<Book>>(),
                 It.IsAny<FindOptions<Book, Book>>(),
                 It.IsAny<CancellationToken>()))
-                .ReturnsAsync(asyncCursor.Object);
+                .ReturnsAsync(SetupCursorWithBooks(books).Object);
 
             // Act
-            var result = await _entityService.SearchAsync(searchText, orderBy);
+            var result = await _entityService.SearchAsync("book", string.Empty);
 
             // Assert
             Assert.That(result, Is.Not.Null);
@@ -468,30 +467,19 @@ namespace MediaSet.Api.Tests.Infrastructure.DataAccess
         public async Task SearchAsync_ShouldBeCaseInsensitive()
         {
             // Arrange
-            var searchText = "FANTASY";
-            var orderBy = "title:asc";
             var books = new List<Book>
             {
                 _bookFaker.Clone().RuleFor(b => b.Title, "fantasy adventure").Generate()
             };
 
-            var asyncCursor = new Mock<IAsyncCursor<Book>>();
-            asyncCursor.Setup(c => c.Current).Returns(books);
-            asyncCursor.SetupSequence(c => c.MoveNext(It.IsAny<CancellationToken>()))
-                .Returns(true)
-                .Returns(false);
-            asyncCursor.SetupSequence(c => c.MoveNextAsync(It.IsAny<CancellationToken>()))
-                .ReturnsAsync(true)
-                .ReturnsAsync(false);
-
             _collectionMock.Setup(c => c.FindAsync(
                 It.IsAny<FilterDefinition<Book>>(),
                 It.IsAny<FindOptions<Book, Book>>(),
                 It.IsAny<CancellationToken>()))
-                .ReturnsAsync(asyncCursor.Object);
+                .ReturnsAsync(SetupCursorWithBooks(books).Object);
 
             // Act
-            var result = await _entityService.SearchAsync(searchText, orderBy);
+            var result = await _entityService.SearchAsync("FANTASY", "title:asc");
 
             // Assert
             Assert.That(result, Is.Not.Null);

--- a/MediaSet.Api/Features/Entities/Endpoints/EntityApi.cs
+++ b/MediaSet.Api/Features/Entities/Endpoints/EntityApi.cs
@@ -26,12 +26,20 @@ internal static class EntityApi
             return result;
         });
 
-        group.MapGet("/search", async (IEntityService<TEntity> entityService, string searchText, string orderBy, CancellationToken cancellationToken) =>
+        group.MapGet("/search", async Task<Results<Ok<IEnumerable<TEntity>>, BadRequest<string>>> (IEntityService<TEntity> entityService, string searchText, string orderBy, CancellationToken cancellationToken) =>
         {
-            logger.LogInformation("Searching {entityType} with query '{searchText}', orderBy {orderBy}", entityType, searchText, orderBy);
-            var result = await entityService.SearchAsync(searchText, orderBy, cancellationToken);
-            logger.LogInformation("Search returned {count} {entityType}", result.Count(), entityType);
-            return result;
+            try
+            {
+                logger.LogInformation("Searching {entityType} with query '{searchText}', orderBy {orderBy}", entityType, searchText, orderBy);
+                var result = await entityService.SearchAsync(searchText, orderBy, cancellationToken);
+                logger.LogInformation("Search returned {count} {entityType}", result.Count(), entityType);
+                return TypedResults.Ok(result);
+            }
+            catch (ArgumentException ex)
+            {
+                logger.LogWarning("Invalid orderBy field for {entityType}: {message}", entityType, ex.Message);
+                return TypedResults.BadRequest(ex.Message);
+            }
         });
 
         group.MapGet("/{id}", async Task<Results<Ok<TEntity>, NotFound>> (IEntityService<TEntity> entityService, string id, CancellationToken cancellationToken) =>

--- a/MediaSet.Api/Infrastructure/DataAccess/EntityService.cs
+++ b/MediaSet.Api/Infrastructure/DataAccess/EntityService.cs
@@ -1,8 +1,10 @@
 using MediaSet.Api.Shared.Models;
 
-using System.Linq.Expressions;
+using System.Reflection;
+using System.Text.RegularExpressions;
 using MediaSet.Api.Infrastructure.Database;
 using MediaSet.Api.Infrastructure.Caching;
+using MongoDB.Bson;
 using MongoDB.Driver;
 using Serilog;
 using SerilogTracing;
@@ -30,27 +32,40 @@ public class EntityService<TEntity> : IEntityService<TEntity> where TEntity : IE
     public async Task<IEnumerable<TEntity>> SearchAsync(string searchText, string orderBy, CancellationToken cancellationToken = default)
     {
         using var activity = Log.Logger.StartActivity("Search {EntityType}", new { EntityType = entityTypeName, searchText, orderBy });
-        
-        string orderByField = "";
+
+        string orderByField = nameof(IEntity.Title);
         bool orderByAscending = true;
+
         if (!string.IsNullOrWhiteSpace(orderBy))
         {
             var orderByArgs = orderBy.Split(":");
-            orderByField = orderByArgs[0];
-            orderByAscending = string.IsNullOrWhiteSpace(orderByArgs[1]) || orderByArgs[1].ToLower().Equals("asc");
-        }
-        var entitySearch = entityCollection.Find(entity => entity.Title.ToLower().Contains(searchText.ToLower()));
-        Expression<Func<TEntity, object>> sortFn = entity => entity.Title;
+            var requestedField = orderByArgs[0];
 
-        if (orderByAscending)
-        {
-            entitySearch.SortBy(sortFn);
+            if (!string.IsNullOrWhiteSpace(requestedField))
+            {
+                var property = typeof(TEntity).GetProperty(requestedField, BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.Instance);
+                if (property == null)
+                {
+                    throw new ArgumentException($"Invalid order by field '{requestedField}' for entity type '{entityTypeName}'.");
+                }
+                orderByField = property.Name;
+            }
+
+            if (orderByArgs.Length >= 2 && !string.IsNullOrWhiteSpace(orderByArgs[1]))
+            {
+                orderByAscending = orderByArgs[1].ToLower() == "asc";
+            }
         }
-        else
-        {
-            entitySearch.SortByDescending(sortFn);
-        }
-        return await entitySearch.ToListAsync(cancellationToken);
+
+        var searchPattern = Regex.Escape(searchText);
+        var filter = Builders<TEntity>.Filter.Regex(entity => entity.Title, new BsonRegularExpression(searchPattern, "i"));
+        var sort = orderByAscending
+            ? Builders<TEntity>.Sort.Ascending(orderByField)
+            : Builders<TEntity>.Sort.Descending(orderByField);
+
+        var findOptions = new FindOptions<TEntity> { Sort = sort };
+        using var cursor = await entityCollection.FindAsync(filter, findOptions, cancellationToken);
+        return await cursor.ToListAsync(cancellationToken);
     }
 
     public async Task<IEnumerable<TEntity>> GetListAsync(CancellationToken cancellationToken = default)

--- a/MediaSet.Remix/app/components/sortable-column-header.test.tsx
+++ b/MediaSet.Remix/app/components/sortable-column-header.test.tsx
@@ -1,0 +1,168 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '~/test/test-utils';
+import SortableColumnHeader from './sortable-column-header';
+
+const mockNavigate = vi.fn();
+
+vi.mock('@remix-run/react', async () => {
+  const actual = await vi.importActual('@remix-run/react');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+    useLocation: () => ({ pathname: '/books' }),
+  };
+});
+
+describe('SortableColumnHeader', () => {
+  beforeEach(() => {
+    mockNavigate.mockClear();
+  });
+
+  it('should render label text', () => {
+    render(
+      <table>
+        <thead>
+          <tr>
+            <SortableColumnHeader label="Title" field="title" currentOrderBy="title:asc" />
+          </tr>
+        </thead>
+      </table>
+    );
+
+    expect(screen.getByText('Title')).toBeInTheDocument();
+  });
+
+  it('should show ascending indicator when active and ascending', () => {
+    const { container } = render(
+      <table>
+        <thead>
+          <tr>
+            <SortableColumnHeader label="Title" field="title" currentOrderBy="title:asc" />
+          </tr>
+        </thead>
+      </table>
+    );
+
+    expect(container.querySelector('svg')).toBeInTheDocument();
+  });
+
+  it('should show descending indicator when active and descending', () => {
+    const { container } = render(
+      <table>
+        <thead>
+          <tr>
+            <SortableColumnHeader label="Title" field="title" currentOrderBy="title:desc" />
+          </tr>
+        </thead>
+      </table>
+    );
+
+    expect(container.querySelector('svg')).toBeInTheDocument();
+  });
+
+  it('should not show indicator when column is not active', () => {
+    const { container } = render(
+      <table>
+        <thead>
+          <tr>
+            <SortableColumnHeader label="Format" field="format" currentOrderBy="title:asc" />
+          </tr>
+        </thead>
+      </table>
+    );
+
+    expect(container.querySelector('svg')).not.toBeInTheDocument();
+  });
+
+  it('should navigate ascending on first click when column is not active', () => {
+    render(
+      <table>
+        <thead>
+          <tr>
+            <SortableColumnHeader label="Format" field="format" currentOrderBy="title:asc" />
+          </tr>
+        </thead>
+      </table>
+    );
+
+    fireEvent.click(screen.getByText('Format'));
+
+    expect(mockNavigate).toHaveBeenCalledWith('/books?orderBy=format%3Aasc');
+  });
+
+  it('should navigate descending when clicking active ascending column', () => {
+    render(
+      <table>
+        <thead>
+          <tr>
+            <SortableColumnHeader label="Title" field="title" currentOrderBy="title:asc" />
+          </tr>
+        </thead>
+      </table>
+    );
+
+    fireEvent.click(screen.getByText('Title'));
+
+    expect(mockNavigate).toHaveBeenCalledWith('/books?orderBy=title%3Adesc');
+  });
+
+  it('should navigate ascending when clicking active descending column', () => {
+    render(
+      <table>
+        <thead>
+          <tr>
+            <SortableColumnHeader label="Title" field="title" currentOrderBy="title:desc" />
+          </tr>
+        </thead>
+      </table>
+    );
+
+    fireEvent.click(screen.getByText('Title'));
+
+    expect(mockNavigate).toHaveBeenCalledWith('/books?orderBy=title%3Aasc');
+  });
+
+  it('should preserve searchText in navigation URL', () => {
+    render(
+      <table>
+        <thead>
+          <tr>
+            <SortableColumnHeader label="Format" field="format" currentOrderBy="title:asc" searchText="gatsby" />
+          </tr>
+        </thead>
+      </table>
+    );
+
+    fireEvent.click(screen.getByText('Format'));
+
+    expect(mockNavigate).toHaveBeenCalledWith('/books?searchText=gatsby&orderBy=format%3Aasc');
+  });
+
+  it('should have aria-sort attribute reflecting current sort state', () => {
+    render(
+      <table>
+        <thead>
+          <tr>
+            <SortableColumnHeader label="Title" field="title" currentOrderBy="title:asc" />
+          </tr>
+        </thead>
+      </table>
+    );
+
+    expect(screen.getByRole('columnheader')).toHaveAttribute('aria-sort', 'ascending');
+  });
+
+  it('should have aria-sort none when column is not active', () => {
+    render(
+      <table>
+        <thead>
+          <tr>
+            <SortableColumnHeader label="Format" field="format" currentOrderBy="title:asc" />
+          </tr>
+        </thead>
+      </table>
+    );
+
+    expect(screen.getByRole('columnheader')).toHaveAttribute('aria-sort', 'none');
+  });
+});

--- a/MediaSet.Remix/app/components/sortable-column-header.tsx
+++ b/MediaSet.Remix/app/components/sortable-column-header.tsx
@@ -1,0 +1,40 @@
+import { useLocation, useNavigate } from '@remix-run/react';
+import { ChevronUp, ChevronDown } from 'lucide-react';
+
+type Props = {
+  label: string;
+  field: string;
+  currentOrderBy: string;
+  searchText?: string | null;
+  className?: string;
+};
+
+export default function SortableColumnHeader({ label, field, currentOrderBy, searchText, className = '' }: Props) {
+  const navigate = useNavigate();
+  const { pathname } = useLocation();
+
+  const [currentField, currentDirection] = currentOrderBy.split(':');
+  const isActive = currentField?.toLowerCase() === field.toLowerCase();
+  const nextDirection = isActive && currentDirection === 'asc' ? 'desc' : 'asc';
+
+  const handleClick = () => {
+    const params = new URLSearchParams();
+    if (searchText) params.set('searchText', searchText);
+    params.set('orderBy', `${field}:${nextDirection}`);
+    navigate(`${pathname}?${params.toString()}`);
+  };
+
+  return (
+    <th
+      className={`pl-2 p-1 border-r border-slate-800 cursor-pointer select-none ${className}`}
+      onClick={handleClick}
+      aria-sort={isActive ? (currentDirection === 'asc' ? 'ascending' : 'descending') : 'none'}
+    >
+      <span className="flex items-center gap-1">
+        {label}
+        {isActive && currentDirection === 'asc' && <ChevronUp size={14} />}
+        {isActive && currentDirection === 'desc' && <ChevronDown size={14} />}
+      </span>
+    </th>
+  );
+}

--- a/MediaSet.Remix/app/routes/$entity._index/components/books.test.tsx
+++ b/MediaSet.Remix/app/routes/$entity._index/components/books.test.tsx
@@ -26,7 +26,7 @@ vi.mock('~/components/delete-dialog', () => ({
     ) : null,
 }));
 
-// Mock Link to avoid router context requirement
+// Mock Remix hooks to avoid router context requirement
 vi.mock('@remix-run/react', async () => {
   const actual = await vi.importActual('@remix-run/react');
   return {
@@ -36,6 +36,8 @@ vi.mock('@remix-run/react', async () => {
         {children}
       </a>
     ),
+    useNavigate: () => vi.fn(),
+    useLocation: () => ({ pathname: '/books' }),
   };
 });
 

--- a/MediaSet.Remix/app/routes/$entity._index/components/books.tsx
+++ b/MediaSet.Remix/app/routes/$entity._index/components/books.tsx
@@ -3,14 +3,17 @@ import { Pencil, Trash2 } from 'lucide-react';
 import { useState } from 'react';
 import DeleteDialog from '~/components/delete-dialog';
 import ImageDisplay from '~/components/image-display';
+import SortableColumnHeader from '~/components/sortable-column-header';
 import { BookEntity, Entity } from '~/models';
 
 type BooksProps = {
   books: BookEntity[];
   apiUrl?: string;
+  orderBy?: string;
+  searchText?: string | null;
 };
 
-export default function Books({ books, apiUrl }: BooksProps) {
+export default function Books({ books, apiUrl, orderBy = 'title:asc', searchText }: BooksProps) {
   const [deleteDialogState, setDeleteDialogState] = useState<{ isOpen: boolean; book: BookEntity | null }>({
     isOpen: false,
     book: null,
@@ -21,11 +24,29 @@ export default function Books({ books, apiUrl }: BooksProps) {
       <table className="text-left w-full">
         <thead className="dark:bg-zinc-700 border-b-2 border-slate-600">
           <tr>
-            <th className="hidden md:table-cell pl-2 p-1 border-r border-slate-800 underline">Cover</th>
-            <th className="pl-2 p-1 border-r border-slate-800 underline">Title</th>
-            <th className="hidden xs:table-cell pl-2 p-1 border-r border-slate-800 underline">Authors</th>
-            <th className="hidden md:table-cell pl-2 p-1 border-r border-slate-800 underline">Format</th>
-            <th className="hidden lg:table-cell pl-2 p-1 border-r border-slate-800 underline">Pages</th>
+            <th className="hidden md:table-cell pl-2 p-1 border-r border-slate-800">Cover</th>
+            <SortableColumnHeader label="Title" field="title" currentOrderBy={orderBy} searchText={searchText} />
+            <SortableColumnHeader
+              label="Authors"
+              field="authors"
+              currentOrderBy={orderBy}
+              searchText={searchText}
+              className="hidden xs:table-cell"
+            />
+            <SortableColumnHeader
+              label="Format"
+              field="format"
+              currentOrderBy={orderBy}
+              searchText={searchText}
+              className="hidden md:table-cell"
+            />
+            <SortableColumnHeader
+              label="Pages"
+              field="pages"
+              currentOrderBy={orderBy}
+              searchText={searchText}
+              className="hidden lg:table-cell"
+            />
             <th className="w-1"></th>
           </tr>
         </thead>

--- a/MediaSet.Remix/app/routes/$entity._index/components/games.test.tsx
+++ b/MediaSet.Remix/app/routes/$entity._index/components/games.test.tsx
@@ -26,7 +26,7 @@ vi.mock('~/components/delete-dialog', () => ({
     ) : null,
 }));
 
-// Mock Link to avoid router context requirement
+// Mock Remix hooks to avoid router context requirement
 vi.mock('@remix-run/react', async () => {
   const actual = await vi.importActual('@remix-run/react');
   return {
@@ -36,6 +36,8 @@ vi.mock('@remix-run/react', async () => {
         {children}
       </a>
     ),
+    useNavigate: () => vi.fn(),
+    useLocation: () => ({ pathname: '/games' }),
   };
 });
 

--- a/MediaSet.Remix/app/routes/$entity._index/components/games.tsx
+++ b/MediaSet.Remix/app/routes/$entity._index/components/games.tsx
@@ -3,14 +3,17 @@ import { Pencil, Trash2 } from 'lucide-react';
 import { useState } from 'react';
 import DeleteDialog from '~/components/delete-dialog';
 import ImageDisplay from '~/components/image-display';
+import SortableColumnHeader from '~/components/sortable-column-header';
 import { GameEntity, Entity } from '~/models';
 
 type GamesProps = {
   games: GameEntity[];
   apiUrl?: string;
+  orderBy?: string;
+  searchText?: string | null;
 };
 
-export default function Games({ games, apiUrl }: GamesProps) {
+export default function Games({ games, apiUrl, orderBy = 'title:asc', searchText }: GamesProps) {
   const [deleteDialogState, setDeleteDialogState] = useState<{ isOpen: boolean; game: GameEntity | null }>({
     isOpen: false,
     game: null,
@@ -21,11 +24,29 @@ export default function Games({ games, apiUrl }: GamesProps) {
       <table className="text-left w-full">
         <thead className="dark:bg-zinc-700 border-b-2 border-slate-600">
           <tr>
-            <th className="hidden md:table-cell pl-2 p-1 border-r border-slate-800 underline">Cover</th>
-            <th className="pl-2 p-1 border-r border-slate-800 underline">Title</th>
-            <th className="hidden md:table-cell pl-2 p-1 border-r border-slate-800 underline">Platform</th>
-            <th className="hidden lg:table-cell pl-2 p-1 border-r border-slate-800 underline">Format</th>
-            <th className="hidden xl:table-cell pl-2 p-1 border-r border-slate-800 underline">Developers</th>
+            <th className="hidden md:table-cell pl-2 p-1 border-r border-slate-800">Cover</th>
+            <SortableColumnHeader label="Title" field="title" currentOrderBy={orderBy} searchText={searchText} />
+            <SortableColumnHeader
+              label="Platform"
+              field="platform"
+              currentOrderBy={orderBy}
+              searchText={searchText}
+              className="hidden md:table-cell"
+            />
+            <SortableColumnHeader
+              label="Format"
+              field="format"
+              currentOrderBy={orderBy}
+              searchText={searchText}
+              className="hidden lg:table-cell"
+            />
+            <SortableColumnHeader
+              label="Developers"
+              field="developers"
+              currentOrderBy={orderBy}
+              searchText={searchText}
+              className="hidden xl:table-cell"
+            />
             <th className="w-1"></th>
           </tr>
         </thead>

--- a/MediaSet.Remix/app/routes/$entity._index/components/movies.test.tsx
+++ b/MediaSet.Remix/app/routes/$entity._index/components/movies.test.tsx
@@ -26,7 +26,7 @@ vi.mock('~/components/delete-dialog', () => ({
     ) : null,
 }));
 
-// Mock Link to avoid router context requirement
+// Mock Remix hooks to avoid router context requirement
 vi.mock('@remix-run/react', async () => {
   const actual = await vi.importActual('@remix-run/react');
   return {
@@ -36,6 +36,8 @@ vi.mock('@remix-run/react', async () => {
         {children}
       </a>
     ),
+    useNavigate: () => vi.fn(),
+    useLocation: () => ({ pathname: '/movies' }),
   };
 });
 

--- a/MediaSet.Remix/app/routes/$entity._index/components/movies.tsx
+++ b/MediaSet.Remix/app/routes/$entity._index/components/movies.tsx
@@ -3,14 +3,17 @@ import { Pencil, Trash2, Check } from 'lucide-react';
 import { useState } from 'react';
 import DeleteDialog from '~/components/delete-dialog';
 import ImageDisplay from '~/components/image-display';
+import SortableColumnHeader from '~/components/sortable-column-header';
 import { MovieEntity, Entity } from '~/models';
 
 type MovieProps = {
   movies: MovieEntity[];
   apiUrl?: string;
+  orderBy?: string;
+  searchText?: string | null;
 };
 
-export default function Movies({ movies, apiUrl }: MovieProps) {
+export default function Movies({ movies, apiUrl, orderBy = 'title:asc', searchText }: MovieProps) {
   const [deleteDialogState, setDeleteDialogState] = useState<{ isOpen: boolean; movie: MovieEntity | null }>({
     isOpen: false,
     movie: null,
@@ -21,11 +24,29 @@ export default function Movies({ movies, apiUrl }: MovieProps) {
       <table className="text-left w-full">
         <thead className="dark:bg-zinc-700 border-b-2 border-slate-600">
           <tr>
-            <th className="hidden md:table-cell pl-2 p-1 border-r border-slate-800 underline">Cover</th>
-            <th className="pl-2 p-1 border-r border-slate-800 underline">Title</th>
-            <th className="hidden md:table-cell pl-2 p-1 border-r border-slate-800 underline">Format</th>
-            <th className="hidden lg:table-cell pl-2 p-1 border-r border-slate-800 underline">Runtime</th>
-            <th className="hidden xl:table-cell pl-2 p-1 border-r border-slate-800 underline">TV Show</th>
+            <th className="hidden md:table-cell pl-2 p-1 border-r border-slate-800">Cover</th>
+            <SortableColumnHeader label="Title" field="title" currentOrderBy={orderBy} searchText={searchText} />
+            <SortableColumnHeader
+              label="Format"
+              field="format"
+              currentOrderBy={orderBy}
+              searchText={searchText}
+              className="hidden md:table-cell"
+            />
+            <SortableColumnHeader
+              label="Runtime"
+              field="runtime"
+              currentOrderBy={orderBy}
+              searchText={searchText}
+              className="hidden lg:table-cell"
+            />
+            <SortableColumnHeader
+              label="TV Show"
+              field="isTvSeries"
+              currentOrderBy={orderBy}
+              searchText={searchText}
+              className="hidden xl:table-cell"
+            />
             <th className="w-1"></th>
           </tr>
         </thead>

--- a/MediaSet.Remix/app/routes/$entity._index/components/musics.test.tsx
+++ b/MediaSet.Remix/app/routes/$entity._index/components/musics.test.tsx
@@ -26,7 +26,7 @@ vi.mock('~/components/delete-dialog', () => ({
     ) : null,
 }));
 
-// Mock Link to avoid router context requirement
+// Mock Remix hooks to avoid router context requirement
 vi.mock('@remix-run/react', async () => {
   const actual = await vi.importActual('@remix-run/react');
   return {
@@ -36,6 +36,8 @@ vi.mock('@remix-run/react', async () => {
         {children}
       </a>
     ),
+    useNavigate: () => vi.fn(),
+    useLocation: () => ({ pathname: '/musics' }),
   };
 });
 

--- a/MediaSet.Remix/app/routes/$entity._index/components/musics.tsx
+++ b/MediaSet.Remix/app/routes/$entity._index/components/musics.tsx
@@ -3,14 +3,17 @@ import { Pencil, Trash2 } from 'lucide-react';
 import { useState } from 'react';
 import DeleteDialog from '~/components/delete-dialog';
 import ImageDisplay from '~/components/image-display';
+import SortableColumnHeader from '~/components/sortable-column-header';
 import { MusicEntity, Entity } from '~/models';
 
 type MusicsProps = {
   musics: MusicEntity[];
   apiUrl?: string;
+  orderBy?: string;
+  searchText?: string | null;
 };
 
-export default function Musics({ musics, apiUrl }: MusicsProps) {
+export default function Musics({ musics, apiUrl, orderBy = 'title:asc', searchText }: MusicsProps) {
   const [deleteDialogState, setDeleteDialogState] = useState<{ isOpen: boolean; music: MusicEntity | null }>({
     isOpen: false,
     music: null,
@@ -21,11 +24,29 @@ export default function Musics({ musics, apiUrl }: MusicsProps) {
       <table className="text-left w-full">
         <thead className="dark:bg-zinc-700 border-b-2 border-slate-600">
           <tr>
-            <th className="hidden md:table-cell pl-2 p-1 border-r border-slate-800 underline">Cover</th>
-            <th className="pl-2 p-1 border-r border-slate-800 underline">Title</th>
-            <th className="hidden md:table-cell pl-2 p-1 border-r border-slate-800 underline">Artist</th>
-            <th className="hidden lg:table-cell pl-2 p-1 border-r border-slate-800 underline">Format</th>
-            <th className="hidden xl:table-cell pl-2 p-1 border-r border-slate-800 underline">Tracks</th>
+            <th className="hidden md:table-cell pl-2 p-1 border-r border-slate-800">Cover</th>
+            <SortableColumnHeader label="Title" field="title" currentOrderBy={orderBy} searchText={searchText} />
+            <SortableColumnHeader
+              label="Artist"
+              field="artist"
+              currentOrderBy={orderBy}
+              searchText={searchText}
+              className="hidden md:table-cell"
+            />
+            <SortableColumnHeader
+              label="Format"
+              field="format"
+              currentOrderBy={orderBy}
+              searchText={searchText}
+              className="hidden lg:table-cell"
+            />
+            <SortableColumnHeader
+              label="Tracks"
+              field="tracks"
+              currentOrderBy={orderBy}
+              searchText={searchText}
+              className="hidden xl:table-cell"
+            />
             <th className="w-1"></th>
           </tr>
         </thead>

--- a/MediaSet.Remix/app/routes/$entity._index/route.test.tsx
+++ b/MediaSet.Remix/app/routes/$entity._index/route.test.tsx
@@ -69,11 +69,12 @@ describe('$entity._index route', () => {
         params: { entity: 'books' },
       } as unknown as Parameters<typeof loader>[0]);
 
-      expect(mockSearchEntities).toHaveBeenCalledWith(Entity.Books, 'test');
+      expect(mockSearchEntities).toHaveBeenCalledWith(Entity.Books, 'test', 'title:asc');
       expect(result).toEqual({
         entities: mockBooks,
         entityType: Entity.Books,
         searchText: 'test',
+        orderBy: 'title:asc',
         apiUrl: expect.any(String),
       });
     });
@@ -96,11 +97,12 @@ describe('$entity._index route', () => {
         params: { entity: 'movies' },
       } as unknown as Parameters<typeof loader>[0]);
 
-      expect(mockSearchEntities).toHaveBeenCalledWith(Entity.Movies, null);
+      expect(mockSearchEntities).toHaveBeenCalledWith(Entity.Movies, null, 'title:asc');
       expect(result).toEqual({
         entities: mockMovies,
         entityType: Entity.Movies,
         searchText: null,
+        orderBy: 'title:asc',
         apiUrl: expect.any(String),
       });
     });
@@ -124,11 +126,12 @@ describe('$entity._index route', () => {
         params: { entity: 'games' },
       } as unknown as Parameters<typeof loader>[0]);
 
-      expect(mockSearchEntities).toHaveBeenCalledWith(Entity.Games, 'action');
+      expect(mockSearchEntities).toHaveBeenCalledWith(Entity.Games, 'action', 'title:asc');
       expect(result).toEqual({
         entities: mockGames,
         entityType: Entity.Games,
         searchText: 'action',
+        orderBy: 'title:asc',
         apiUrl: expect.any(String),
       });
     });
@@ -152,11 +155,12 @@ describe('$entity._index route', () => {
         params: { entity: 'musics' },
       } as unknown as Parameters<typeof loader>[0]);
 
-      expect(mockSearchEntities).toHaveBeenCalledWith(Entity.Musics, 'rock');
+      expect(mockSearchEntities).toHaveBeenCalledWith(Entity.Musics, 'rock', 'title:asc');
       expect(result).toEqual({
         entities: mockMusics,
         entityType: Entity.Musics,
         searchText: 'rock',
+        orderBy: 'title:asc',
         apiUrl: expect.any(String),
       });
     });
@@ -175,6 +179,7 @@ describe('$entity._index route', () => {
         entities: [],
         entityType: Entity.Books,
         searchText: 'nonexistent',
+        orderBy: 'title:asc',
         apiUrl: expect.any(String),
       });
     });
@@ -221,7 +226,7 @@ describe('$entity._index route', () => {
       } as unknown as Parameters<typeof loader>[0]);
 
       expect(mockGetEntityFromParams).toHaveBeenCalledWith({ entity: 'games' });
-      expect(mockSearchEntities).toHaveBeenCalledWith(Entity.Games, 'zelda');
+      expect(mockSearchEntities).toHaveBeenCalledWith(Entity.Games, 'zelda', 'title:asc');
     });
 
     it('should extract search text from URL query parameters', async () => {
@@ -234,7 +239,7 @@ describe('$entity._index route', () => {
         params: { entity: 'books' },
       } as unknown as Parameters<typeof loader>[0]);
 
-      expect(mockSearchEntities).toHaveBeenCalledWith(Entity.Books, 'multiple words');
+      expect(mockSearchEntities).toHaveBeenCalledWith(Entity.Books, 'multiple words', 'title:asc');
     });
 
     it('should handle null search text when not provided', async () => {
@@ -247,7 +252,35 @@ describe('$entity._index route', () => {
         params: { entity: 'movies' },
       } as unknown as Parameters<typeof loader>[0]);
 
-      expect(mockSearchEntities).toHaveBeenCalledWith(Entity.Movies, null);
+      expect(mockSearchEntities).toHaveBeenCalledWith(Entity.Movies, null, 'title:asc');
+    });
+
+    it('should pass orderBy from URL to searchEntities', async () => {
+      mockGetEntityFromParams.mockReturnValue(Entity.Books);
+      mockSearchEntities.mockResolvedValue([]);
+
+      const mockRequest = new Request('http://localhost/books?orderBy=format:desc');
+      const result = await loader({
+        request: mockRequest,
+        params: { entity: 'books' },
+      } as unknown as Parameters<typeof loader>[0]);
+
+      expect(mockSearchEntities).toHaveBeenCalledWith(Entity.Books, null, 'format:desc');
+      expect(result).toMatchObject({ orderBy: 'format:desc' });
+    });
+
+    it('should default orderBy to title:asc when not provided', async () => {
+      mockGetEntityFromParams.mockReturnValue(Entity.Books);
+      mockSearchEntities.mockResolvedValue([]);
+
+      const mockRequest = new Request('http://localhost/books?searchText=test');
+      const result = await loader({
+        request: mockRequest,
+        params: { entity: 'books' },
+      } as unknown as Parameters<typeof loader>[0]);
+
+      expect(mockSearchEntities).toHaveBeenCalledWith(Entity.Books, 'test', 'title:asc');
+      expect(result).toMatchObject({ orderBy: 'title:asc' });
     });
   });
 });

--- a/MediaSet.Remix/app/routes/$entity._index/route.tsx
+++ b/MediaSet.Remix/app/routes/$entity._index/route.tsx
@@ -21,15 +21,16 @@ export const loader = async ({ request, params }: LoaderFunctionArgs) => {
   invariant(params.entity, 'Missing entity param');
   const url = new URL(request.url);
   const searchText = url.searchParams.get('searchText');
+  const orderBy = url.searchParams.get('orderBy') ?? 'title:asc';
   const entityType: Entity = getEntityFromParams(params);
 
-  const entities = await searchEntities(entityType, searchText);
+  const entities = await searchEntities(entityType, searchText, orderBy);
   const apiUrl = clientApiUrl;
-  return { entities, entityType, searchText, apiUrl };
+  return { entities, entityType, searchText, orderBy, apiUrl };
 };
 
 export default function Index() {
-  const { entities, entityType, searchText, apiUrl } = useLoaderData<typeof loader>();
+  const { entities, entityType, searchText, orderBy, apiUrl } = useLoaderData<typeof loader>();
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -92,10 +93,18 @@ export default function Index() {
           </div>
         ) : (
           <>
-            {entityType === Entity.Books && <Books books={entities as BookEntity[]} apiUrl={apiUrl} />}
-            {entityType === Entity.Movies && <Movies movies={entities as MovieEntity[]} apiUrl={apiUrl} />}
-            {entityType === Entity.Games && <Games games={entities as GameEntity[]} apiUrl={apiUrl} />}
-            {entityType === Entity.Musics && <Musics musics={entities as MusicEntity[]} apiUrl={apiUrl} />}
+            {entityType === Entity.Books && (
+              <Books books={entities as BookEntity[]} apiUrl={apiUrl} orderBy={orderBy} searchText={searchText} />
+            )}
+            {entityType === Entity.Movies && (
+              <Movies movies={entities as MovieEntity[]} apiUrl={apiUrl} orderBy={orderBy} searchText={searchText} />
+            )}
+            {entityType === Entity.Games && (
+              <Games games={entities as GameEntity[]} apiUrl={apiUrl} orderBy={orderBy} searchText={searchText} />
+            )}
+            {entityType === Entity.Musics && (
+              <Musics musics={entities as MusicEntity[]} apiUrl={apiUrl} orderBy={orderBy} searchText={searchText} />
+            )}
           </>
         )}
       </div>


### PR DESCRIPTION
## Summary

- **Backend**: `EntityService.SearchAsync` now validates the `orderBy` field against entity properties using reflection (case-insensitive), throws `ArgumentException` for invalid fields, and sorts dynamically instead of hardcoding `Title`. The search endpoint returns `400 BadRequest` for invalid fields.
- **Frontend**: New `SortableColumnHeader` component renders clickable column headers with ascending/descending chevron indicators and `aria-sort` attributes. Clicking a column sorts ascending; clicking again toggles to descending.
- **Default sort**: `title:asc` when no `orderBy` param is present. Cover image column is not sortable.
- **Tests**: New and updated backend unit tests for field validation and dynamic sorting; new `SortableColumnHeader` tests; updated route and component tests.

## Test plan

- [x] Run backend tests: `dotnet test MediaSet.Api.Tests/MediaSet.Api.Tests.csproj`
- [x] Run frontend tests: `cd MediaSet.Remix && npm test`
- [x] Navigate to a Books/Movies/Games/Musics list — default sort is Title ascending
- [x] Click a column header — list reloads sorted by that column ascending
- [x] Click the same column header again — list reloads sorted descending
- [x] Verify sort indicator (chevron) appears on the active column
- [x] Verify Cover column has no sort indicator/click behavior
- [x] Test with a search active — verify `searchText` is preserved in URL when sorting
- [x] Verify API returns `400` for an invalid `orderBy` field (e.g., `?orderBy=bogus:asc`)

closes #525

🤖 Generated with [Claude Code](https://claude.com/claude-code)