### PR TITLE
feat(ui): mobile card layout for entity list views

### DIFF
--- a/MediaSet.Remix/app/routes/$entity._index/components/books.test.tsx
+++ b/MediaSet.Remix/app/routes/$entity._index/components/books.test.tsx
@@ -80,16 +80,16 @@ describe('Books component', () => {
       expect(screen.getByText('Format')).toBeInTheDocument();
       expect(screen.getByText('Pages')).toBeInTheDocument();
 
-      expect(screen.getByText('The Great Gatsby')).toBeInTheDocument();
-      expect(screen.getByText('To Kill a Mockingbird')).toBeInTheDocument();
-      expect(screen.getByText('Multiple Authors Book')).toBeInTheDocument();
+      expect(screen.getAllByText('The Great Gatsby')[0]).toBeInTheDocument();
+      expect(screen.getAllByText('To Kill a Mockingbird')[0]).toBeInTheDocument();
+      expect(screen.getAllByText('Multiple Authors Book')[0]).toBeInTheDocument();
     });
 
     it('should display book titles as links to detail pages', () => {
       render(<Books books={mockBooks} />);
 
-      expect(screen.getByText('The Great Gatsby')).toHaveAttribute('href', '/books/1');
-      expect(screen.getByText('To Kill a Mockingbird')).toHaveAttribute('href', '/books/2');
+      expect(screen.getAllByText('The Great Gatsby')[0]).toHaveAttribute('href', '/books/1');
+      expect(screen.getAllByText('To Kill a Mockingbird')[0]).toHaveAttribute('href', '/books/2');
     });
 
     it('should display authors and format correctly', () => {
@@ -120,12 +120,12 @@ describe('Books component', () => {
       render(<Books books={mockBooks} />);
 
       const editLinks = screen.getAllByRole('link', { name: /edit/i });
-      expect(editLinks).toHaveLength(mockBooks.length);
+      expect(editLinks).toHaveLength(mockBooks.length * 2);
       expect(editLinks[0]).toHaveAttribute('href', '/books/1/edit');
       expect(editLinks[1]).toHaveAttribute('href', '/books/2/edit');
 
       const deleteButtons = screen.getAllByRole('button', { name: /delete/i });
-      expect(deleteButtons).toHaveLength(mockBooks.length);
+      expect(deleteButtons).toHaveLength(mockBooks.length * 2);
     });
 
     it('should handle book with subtitle', () => {
@@ -141,7 +141,7 @@ describe('Books component', () => {
 
       render(<Books books={booksWithSubtitle} />);
 
-      expect(screen.getByText('A Book: The Subtitle')).toBeInTheDocument();
+      expect(screen.getAllByText('A Book: The Subtitle')[0]).toBeInTheDocument();
     });
 
     it('should handle book without subtitle', () => {
@@ -156,7 +156,7 @@ describe('Books component', () => {
 
       render(<Books books={booksWithoutSubtitle} />);
 
-      expect(screen.getByText('A Book')).toBeInTheDocument();
+      expect(screen.getAllByText('A Book')[0]).toBeInTheDocument();
     });
 
     it('should handle empty authors array', () => {
@@ -171,7 +171,7 @@ describe('Books component', () => {
 
       render(<Books books={booksNoAuthors} />);
 
-      expect(screen.getByText('Anonymous Book')).toBeInTheDocument();
+      expect(screen.getAllByText('Anonymous Book')[0]).toBeInTheDocument();
     });
 
     it('should handle book with undefined authors', () => {
@@ -185,7 +185,7 @@ describe('Books component', () => {
 
       render(<Books books={booksNoAuthors} />);
 
-      expect(screen.getByText('Anonymous Book')).toBeInTheDocument();
+      expect(screen.getAllByText('Anonymous Book')[0]).toBeInTheDocument();
     });
   });
 
@@ -272,7 +272,7 @@ describe('Books component', () => {
       const singleBook: BookEntity[] = [mockBooks[0]];
       render(<Books books={singleBook} />);
 
-      expect(screen.getByText('The Great Gatsby')).toBeInTheDocument();
+      expect(screen.getAllByText('The Great Gatsby')[0]).toBeInTheDocument();
       expect(screen.getAllByRole('row')).toHaveLength(2); // header + 1 book
     });
 
@@ -289,7 +289,7 @@ describe('Books component', () => {
 
       render(<Books books={longTitleBook} />);
 
-      expect(screen.getByText(/This is a very long book title/)).toBeInTheDocument();
+      expect(screen.getAllByText(/This is a very long book title/)[0]).toBeInTheDocument();
     });
 
     it('should trim trailing spaces in author names', () => {
@@ -313,7 +313,7 @@ describe('Books component', () => {
       render(<Books books={mockBooks} />);
 
       const editButtons = screen.getAllByRole('link', { name: /edit/i });
-      expect(editButtons).toHaveLength(mockBooks.length);
+      expect(editButtons).toHaveLength(mockBooks.length * 2);
 
       editButtons.forEach((btn: HTMLElement) => {
         expect(btn).toHaveAttribute('aria-label', 'Edit');
@@ -324,7 +324,7 @@ describe('Books component', () => {
       render(<Books books={mockBooks} />);
 
       const deleteButtons = screen.getAllByRole('button', { name: /delete/i });
-      expect(deleteButtons).toHaveLength(mockBooks.length);
+      expect(deleteButtons).toHaveLength(mockBooks.length * 2);
 
       deleteButtons.forEach((btn: HTMLElement) => {
         expect(btn).toHaveAttribute('aria-label', 'Delete');

--- a/MediaSet.Remix/app/routes/$entity._index/components/books.tsx
+++ b/MediaSet.Remix/app/routes/$entity._index/components/books.tsx
@@ -21,7 +21,48 @@ export default function Books({ books, apiUrl, orderBy = 'title:asc', searchText
 
   return (
     <>
-      <table className="text-left w-full">
+      <div className="md:hidden flex flex-col divide-y divide-slate-700">
+        {books.map((book) => (
+          <div key={book.id} className="flex flex-row items-center gap-3 py-2 px-2 dark:hover:bg-zinc-800">
+            {book.coverImage && (
+              <div className="flex-shrink-0">
+                <ImageDisplay
+                  imageData={book.coverImage}
+                  alt={`${book.title} cover`}
+                  entityType={Entity.Books}
+                  entityId={book.id}
+                  apiUrl={apiUrl}
+                  size="xsmall"
+                />
+              </div>
+            )}
+            <div className="flex-1 min-w-0">
+              <Link to={`/books/${book.id}`} className="font-medium block truncate">
+                {book.title}
+                {book.subtitle && `: ${book.subtitle}`}
+              </Link>
+              <div className="text-xs text-gray-400 truncate">
+                {[book.authors?.map((a) => a.trimEnd()).join(', '), book.format].filter(Boolean).join(' · ')}
+              </div>
+            </div>
+            <div className="flex flex-row gap-3 flex-shrink-0">
+              <Link to={`/books/${book.id}/edit`} aria-label="Edit" title="Edit">
+                <Pencil size={18} />
+              </Link>
+              <button
+                onClick={() => setDeleteDialogState({ isOpen: true, book })}
+                className="link"
+                type="button"
+                aria-label="Delete"
+                title="Delete"
+              >
+                <Trash2 size={18} />
+              </button>
+            </div>
+          </div>
+        ))}
+      </div>
+      <table className="hidden md:table text-left w-full">
         <thead className="dark:bg-zinc-700 border-b-2 border-slate-600">
           <tr>
             <th className="hidden md:table-cell pl-2 p-1 border-r border-slate-800">Cover</th>

--- a/MediaSet.Remix/app/routes/$entity._index/components/games.test.tsx
+++ b/MediaSet.Remix/app/routes/$entity._index/components/games.test.tsx
@@ -79,16 +79,16 @@ describe('Games component', () => {
       expect(screen.getByText('Format')).toBeInTheDocument();
       expect(screen.getByText('Developers')).toBeInTheDocument();
 
-      expect(screen.getByText('Elden Ring')).toBeInTheDocument();
-      expect(screen.getByText('The Legend of Zelda: Breath of the Wild')).toBeInTheDocument();
-      expect(screen.getByText("Baldur's Gate 3")).toBeInTheDocument();
+      expect(screen.getAllByText('Elden Ring')[0]).toBeInTheDocument();
+      expect(screen.getAllByText('The Legend of Zelda: Breath of the Wild')[0]).toBeInTheDocument();
+      expect(screen.getAllByText("Baldur's Gate 3")[0]).toBeInTheDocument();
     });
 
     it('should display game titles as links to detail pages', () => {
       render(<Games games={mockGames} />);
 
-      expect(screen.getByText('Elden Ring')).toHaveAttribute('href', '/games/1');
-      expect(screen.getByText('The Legend of Zelda: Breath of the Wild')).toHaveAttribute('href', '/games/2');
+      expect(screen.getAllByText('Elden Ring')[0]).toHaveAttribute('href', '/games/1');
+      expect(screen.getAllByText('The Legend of Zelda: Breath of the Wild')[0]).toHaveAttribute('href', '/games/2');
     });
 
     it('should display platform, format, and developers', () => {
@@ -109,12 +109,12 @@ describe('Games component', () => {
       render(<Games games={mockGames} />);
 
       const editLinks = screen.getAllByRole('link', { name: /edit/i });
-      expect(editLinks).toHaveLength(mockGames.length);
+      expect(editLinks).toHaveLength(mockGames.length * 2);
       expect(editLinks[0]).toHaveAttribute('href', '/games/1/edit');
       expect(editLinks[1]).toHaveAttribute('href', '/games/2/edit');
 
       const deleteButtons = screen.getAllByRole('button', { name: /delete/i });
-      expect(deleteButtons).toHaveLength(mockGames.length);
+      expect(deleteButtons).toHaveLength(mockGames.length * 2);
     });
 
     it('should handle game without platform', () => {
@@ -130,7 +130,7 @@ describe('Games component', () => {
 
       render(<Games games={gamesNoPlatform} />);
 
-      expect(screen.getByText('Test Game')).toBeInTheDocument();
+      expect(screen.getAllByText('Test Game')[0]).toBeInTheDocument();
     });
 
     it('should handle game without developers', () => {
@@ -146,7 +146,7 @@ describe('Games component', () => {
 
       render(<Games games={gamesNoDevelopers} />);
 
-      expect(screen.getByText('Test Game')).toBeInTheDocument();
+      expect(screen.getAllByText('Test Game')[0]).toBeInTheDocument();
     });
 
     it('should handle game with multiple developers', () => {
@@ -162,6 +162,7 @@ describe('Games component', () => {
 
       render(<Games games={gamesMultipleDev} />);
 
+      expect(screen.getAllByText('Test Game')[0]).toBeInTheDocument();
       expect(screen.getByText('Studio A, Studio B, Studio C')).toBeInTheDocument();
     });
 
@@ -178,6 +179,7 @@ describe('Games component', () => {
 
       render(<Games games={gamesSpacedDevelopers} />);
 
+      expect(screen.getAllByText('Test Game')[0]).toBeInTheDocument();
       expect(screen.getByText('Dev Studio, Another Studio')).toBeInTheDocument();
     });
   });
@@ -280,9 +282,9 @@ describe('Games component', () => {
 
       render(<Games games={gameDifferentPlatforms} />);
 
-      expect(screen.getByText('Xbox Series X')).toBeInTheDocument();
-      expect(screen.getByText('iOS')).toBeInTheDocument();
-      expect(screen.getByText('itch.io')).toBeInTheDocument();
+      expect(screen.getAllByText('Xbox Series X')[0]).toBeInTheDocument();
+      expect(screen.getAllByText('iOS')[0]).toBeInTheDocument();
+      expect(screen.getAllByText('itch.io')[0]).toBeInTheDocument();
     });
   });
 
@@ -299,7 +301,7 @@ describe('Games component', () => {
       const singleGame: GameEntity[] = [mockGames[0]];
       render(<Games games={singleGame} />);
 
-      expect(screen.getByText('Elden Ring')).toBeInTheDocument();
+      expect(screen.getAllByText('Elden Ring')[0]).toBeInTheDocument();
       expect(screen.getAllByRole('row')).toHaveLength(2); // header + 1 game
     });
 
@@ -317,7 +319,7 @@ describe('Games component', () => {
 
       render(<Games games={longTitleGame} />);
 
-      expect(screen.getByText(/This is a very long game title/)).toBeInTheDocument();
+      expect(screen.getAllByText(/This is a very long game title/)[0]).toBeInTheDocument();
     });
 
     it('should handle many games', () => {
@@ -331,8 +333,8 @@ describe('Games component', () => {
 
       render(<Games games={manyGames} />);
 
-      expect(screen.getByText('Game 0')).toBeInTheDocument();
-      expect(screen.getByText('Game 49')).toBeInTheDocument();
+      expect(screen.getAllByText('Game 0')[0]).toBeInTheDocument();
+      expect(screen.getAllByText('Game 49')[0]).toBeInTheDocument();
       const rows = screen.getAllByRole('row');
       expect(rows).toHaveLength(51); // header + 50 games
     });
@@ -358,7 +360,7 @@ describe('Games component', () => {
 
       render(<Games games={gamesEmptyDevelopers} />);
 
-      expect(screen.getByText('Unknown Developer Game')).toBeInTheDocument();
+      expect(screen.getAllByText('Unknown Developer Game')[0]).toBeInTheDocument();
     });
   });
 
@@ -367,7 +369,7 @@ describe('Games component', () => {
       render(<Games games={mockGames} />);
 
       const editButtons = screen.getAllByRole('link', { name: /edit/i });
-      expect(editButtons).toHaveLength(mockGames.length);
+      expect(editButtons).toHaveLength(mockGames.length * 2);
 
       editButtons.forEach((btn: HTMLElement) => {
         expect(btn).toHaveAttribute('aria-label', 'Edit');
@@ -378,7 +380,7 @@ describe('Games component', () => {
       render(<Games games={mockGames} />);
 
       const deleteButtons = screen.getAllByRole('button', { name: /delete/i });
-      expect(deleteButtons).toHaveLength(mockGames.length);
+      expect(deleteButtons).toHaveLength(mockGames.length * 2);
 
       deleteButtons.forEach((btn: HTMLElement) => {
         expect(btn).toHaveAttribute('aria-label', 'Delete');

--- a/MediaSet.Remix/app/routes/$entity._index/components/games.tsx
+++ b/MediaSet.Remix/app/routes/$entity._index/components/games.tsx
@@ -21,7 +21,47 @@ export default function Games({ games, apiUrl, orderBy = 'title:asc', searchText
 
   return (
     <>
-      <table className="text-left w-full">
+      <div className="md:hidden flex flex-col divide-y divide-slate-700">
+        {games.map((game) => (
+          <div key={game.id} className="flex flex-row items-center gap-3 py-2 px-2 dark:hover:bg-zinc-800">
+            {game.coverImage && (
+              <div className="flex-shrink-0">
+                <ImageDisplay
+                  imageData={game.coverImage}
+                  alt={`${game.title} cover`}
+                  entityType={Entity.Games}
+                  entityId={game.id}
+                  apiUrl={apiUrl}
+                  size="xsmall"
+                />
+              </div>
+            )}
+            <div className="flex-1 min-w-0">
+              <Link to={`/games/${game.id}`} className="font-medium block truncate">
+                {game.title}
+              </Link>
+              <div className="text-xs text-gray-400 truncate">
+                {[game.platform, game.format].filter(Boolean).join(' · ')}
+              </div>
+            </div>
+            <div className="flex flex-row gap-3 flex-shrink-0">
+              <Link to={`/games/${game.id}/edit`} aria-label="Edit" title="Edit">
+                <Pencil size={18} />
+              </Link>
+              <button
+                onClick={() => setDeleteDialogState({ isOpen: true, game })}
+                className="link"
+                type="button"
+                aria-label="Delete"
+                title="Delete"
+              >
+                <Trash2 size={18} />
+              </button>
+            </div>
+          </div>
+        ))}
+      </div>
+      <table className="hidden md:table text-left w-full">
         <thead className="dark:bg-zinc-700 border-b-2 border-slate-600">
           <tr>
             <th className="hidden md:table-cell pl-2 p-1 border-r border-slate-800">Cover</th>

--- a/MediaSet.Remix/app/routes/$entity._index/components/movies.test.tsx
+++ b/MediaSet.Remix/app/routes/$entity._index/components/movies.test.tsx
@@ -79,16 +79,16 @@ describe('Movies component', () => {
       expect(screen.getByText('Runtime')).toBeInTheDocument();
       expect(screen.getByText('TV Show')).toBeInTheDocument();
 
-      expect(screen.getByText('The Shawshank Redemption')).toBeInTheDocument();
-      expect(screen.getByText('Breaking Bad')).toBeInTheDocument();
-      expect(screen.getByText('Inception')).toBeInTheDocument();
+      expect(screen.getAllByText('The Shawshank Redemption')[0]).toBeInTheDocument();
+      expect(screen.getAllByText('Breaking Bad')[0]).toBeInTheDocument();
+      expect(screen.getAllByText('Inception')[0]).toBeInTheDocument();
     });
 
     it('should display movie titles as links to detail pages', () => {
       render(<Movies movies={mockMovies} />);
 
-      expect(screen.getByText('The Shawshank Redemption')).toHaveAttribute('href', '/movies/1');
-      expect(screen.getByText('Breaking Bad')).toHaveAttribute('href', '/movies/2');
+      expect(screen.getAllByText('The Shawshank Redemption')[0]).toHaveAttribute('href', '/movies/1');
+      expect(screen.getAllByText('Breaking Bad')[0]).toHaveAttribute('href', '/movies/2');
     });
 
     it('should display format and runtime', () => {
@@ -106,12 +106,12 @@ describe('Movies component', () => {
       render(<Movies movies={mockMovies} />);
 
       const editLinks = screen.getAllByRole('link', { name: /edit/i });
-      expect(editLinks).toHaveLength(mockMovies.length);
+      expect(editLinks).toHaveLength(mockMovies.length * 2);
       expect(editLinks[0]).toHaveAttribute('href', '/movies/1/edit');
       expect(editLinks[1]).toHaveAttribute('href', '/movies/2/edit');
 
       const deleteButtons = screen.getAllByRole('button', { name: /delete/i });
-      expect(deleteButtons).toHaveLength(mockMovies.length);
+      expect(deleteButtons).toHaveLength(mockMovies.length * 2);
     });
 
     it('should handle movie without runtime', () => {
@@ -126,7 +126,7 @@ describe('Movies component', () => {
 
       render(<Movies movies={moviesNoRuntime} />);
 
-      expect(screen.getByText('Test Movie')).toBeInTheDocument();
+      expect(screen.getAllByText('Test Movie')[0]).toBeInTheDocument();
       expect(screen.getByText('0')).toBeInTheDocument();
     });
 
@@ -143,7 +143,7 @@ describe('Movies component', () => {
 
       render(<Movies movies={moviesNoFlag} />);
 
-      expect(screen.getByText('Test Movie')).toBeInTheDocument();
+      expect(screen.getAllByText('Test Movie')[0]).toBeInTheDocument();
     });
   });
 
@@ -152,11 +152,11 @@ describe('Movies component', () => {
       render(<Movies movies={mockMovies} />);
 
       // Breaking Bad (id: 2) is a TV series
-      const breakingBadRow = screen.getByText('Breaking Bad').closest('tr');
+      const breakingBadRow = screen.getAllByText('Breaking Bad')[1].closest('tr');
       expect(breakingBadRow).toBeInTheDocument();
 
       // Inception (id: 3) is not a TV series
-      const inceptionRow = screen.getByText('Inception').closest('tr');
+      const inceptionRow = screen.getAllByText('Inception')[1].closest('tr');
       expect(inceptionRow).toBeInTheDocument();
     });
 
@@ -186,9 +186,9 @@ describe('Movies component', () => {
 
       render(<Movies movies={mixedMovies} />);
 
-      expect(screen.getByText('Movie Only')).toBeInTheDocument();
-      expect(screen.getByText('TV Series Only')).toBeInTheDocument();
-      expect(screen.getByText('No Flag')).toBeInTheDocument();
+      expect(screen.getAllByText('Movie Only')[0]).toBeInTheDocument();
+      expect(screen.getAllByText('TV Series Only')[0]).toBeInTheDocument();
+      expect(screen.getAllByText('No Flag')[0]).toBeInTheDocument();
     });
   });
 
@@ -267,7 +267,7 @@ describe('Movies component', () => {
       const singleMovie: MovieEntity[] = [mockMovies[0]];
       render(<Movies movies={singleMovie} />);
 
-      expect(screen.getByText('The Shawshank Redemption')).toBeInTheDocument();
+      expect(screen.getAllByText('The Shawshank Redemption')[0]).toBeInTheDocument();
       expect(screen.getAllByRole('row')).toHaveLength(2); // header + 1 movie
     });
 
@@ -285,7 +285,7 @@ describe('Movies component', () => {
 
       render(<Movies movies={longTitleMovie} />);
 
-      expect(screen.getByText(/This is a very long movie title/)).toBeInTheDocument();
+      expect(screen.getAllByText(/This is a very long movie title/)[0]).toBeInTheDocument();
     });
 
     it('should handle very large runtime', () => {
@@ -325,7 +325,7 @@ describe('Movies component', () => {
       render(<Movies movies={mockMovies} />);
 
       const editButtons = screen.getAllByRole('link', { name: /edit/i });
-      expect(editButtons).toHaveLength(mockMovies.length);
+      expect(editButtons).toHaveLength(mockMovies.length * 2);
 
       editButtons.forEach((btn: HTMLElement) => {
         expect(btn).toHaveAttribute('aria-label', 'Edit');
@@ -336,7 +336,7 @@ describe('Movies component', () => {
       render(<Movies movies={mockMovies} />);
 
       const deleteButtons = screen.getAllByRole('button', { name: /delete/i });
-      expect(deleteButtons).toHaveLength(mockMovies.length);
+      expect(deleteButtons).toHaveLength(mockMovies.length * 2);
 
       deleteButtons.forEach((btn: HTMLElement) => {
         expect(btn).toHaveAttribute('aria-label', 'Delete');

--- a/MediaSet.Remix/app/routes/$entity._index/components/movies.tsx
+++ b/MediaSet.Remix/app/routes/$entity._index/components/movies.tsx
@@ -21,7 +21,49 @@ export default function Movies({ movies, apiUrl, orderBy = 'title:asc', searchTe
 
   return (
     <>
-      <table className="text-left w-full">
+      <div className="md:hidden flex flex-col divide-y divide-slate-700">
+        {movies.map((movie) => (
+          <div key={movie.id} className="flex flex-row items-center gap-3 py-2 px-2 dark:hover:bg-zinc-800">
+            {movie.coverImage && (
+              <div className="flex-shrink-0">
+                <ImageDisplay
+                  imageData={movie.coverImage}
+                  alt={`${movie.title} cover`}
+                  entityType={Entity.Movies}
+                  entityId={movie.id}
+                  apiUrl={apiUrl}
+                  size="xsmall"
+                />
+              </div>
+            )}
+            <div className="flex-1 min-w-0">
+              <Link to={`/movies/${movie.id}`} className="font-medium block truncate">
+                {movie.title}
+              </Link>
+              <div className="text-xs text-gray-400 truncate">
+                {[movie.format, movie.runtime ? `${movie.runtime} min` : null, movie.isTvSeries ? 'TV Show' : null]
+                  .filter(Boolean)
+                  .join(' · ')}
+              </div>
+            </div>
+            <div className="flex flex-row gap-3 flex-shrink-0">
+              <Link to={`/movies/${movie.id}/edit`} aria-label="Edit" title="Edit">
+                <Pencil size={18} />
+              </Link>
+              <button
+                onClick={() => setDeleteDialogState({ isOpen: true, movie })}
+                className="link"
+                type="button"
+                aria-label="Delete"
+                title="Delete"
+              >
+                <Trash2 size={18} />
+              </button>
+            </div>
+          </div>
+        ))}
+      </div>
+      <table className="hidden md:table text-left w-full">
         <thead className="dark:bg-zinc-700 border-b-2 border-slate-600">
           <tr>
             <th className="hidden md:table-cell pl-2 p-1 border-r border-slate-800">Cover</th>

--- a/MediaSet.Remix/app/routes/$entity._index/components/musics.test.tsx
+++ b/MediaSet.Remix/app/routes/$entity._index/components/musics.test.tsx
@@ -79,16 +79,16 @@ describe('Musics component', () => {
       expect(screen.getByText('Format')).toBeInTheDocument();
       expect(screen.getByText('Tracks')).toBeInTheDocument();
 
-      expect(screen.getByText('Abbey Road')).toBeInTheDocument();
-      expect(screen.getByText('Dark Side of the Moon')).toBeInTheDocument();
-      expect(screen.getByText('Led Zeppelin IV')).toBeInTheDocument();
+      expect(screen.getAllByText('Abbey Road')[0]).toBeInTheDocument();
+      expect(screen.getAllByText('Dark Side of the Moon')[0]).toBeInTheDocument();
+      expect(screen.getAllByText('Led Zeppelin IV')[0]).toBeInTheDocument();
     });
 
     it('should display music titles as links to detail pages', () => {
       render(<Musics musics={mockMusics} />);
 
-      expect(screen.getByText('Abbey Road')).toHaveAttribute('href', '/musics/1');
-      expect(screen.getByText('Dark Side of the Moon')).toHaveAttribute('href', '/musics/2');
+      expect(screen.getAllByText('Abbey Road')[0]).toHaveAttribute('href', '/musics/1');
+      expect(screen.getAllByText('Dark Side of the Moon')[0]).toHaveAttribute('href', '/musics/2');
     });
 
     it('should display artist, format, and track count', () => {
@@ -108,12 +108,12 @@ describe('Musics component', () => {
       render(<Musics musics={mockMusics} />);
 
       const editLinks = screen.getAllByRole('link', { name: /edit/i });
-      expect(editLinks).toHaveLength(mockMusics.length);
+      expect(editLinks).toHaveLength(mockMusics.length * 2);
       expect(editLinks[0]).toHaveAttribute('href', '/musics/1/edit');
       expect(editLinks[1]).toHaveAttribute('href', '/musics/2/edit');
 
       const deleteButtons = screen.getAllByRole('button', { name: /delete/i });
-      expect(deleteButtons).toHaveLength(mockMusics.length);
+      expect(deleteButtons).toHaveLength(mockMusics.length * 2);
     });
 
     it('should handle music without artist', () => {
@@ -129,7 +129,7 @@ describe('Musics component', () => {
 
       render(<Musics musics={musicsNoArtist} />);
 
-      expect(screen.getByText('Unknown Artist Album')).toBeInTheDocument();
+      expect(screen.getAllByText('Unknown Artist Album')[0]).toBeInTheDocument();
     });
 
     it('should handle music without tracks count', () => {
@@ -145,7 +145,7 @@ describe('Musics component', () => {
 
       render(<Musics musics={musicsNoTracks} />);
 
-      expect(screen.getByText('Test Album')).toBeInTheDocument();
+      expect(screen.getAllByText('Test Album')[0]).toBeInTheDocument();
     });
 
     it('should handle music without format', () => {
@@ -161,7 +161,7 @@ describe('Musics component', () => {
 
       render(<Musics musics={musicsNoFormat} />);
 
-      expect(screen.getByText('Test Album')).toBeInTheDocument();
+      expect(screen.getAllByText('Test Album')[0]).toBeInTheDocument();
     });
 
     it('should handle different formats', () => {
@@ -283,7 +283,7 @@ describe('Musics component', () => {
       const singleMusic: MusicEntity[] = [mockMusics[0]];
       render(<Musics musics={singleMusic} />);
 
-      expect(screen.getByText('Abbey Road')).toBeInTheDocument();
+      expect(screen.getAllByText('Abbey Road')[0]).toBeInTheDocument();
       expect(screen.getAllByRole('row')).toHaveLength(2); // header + 1 music
     });
 
@@ -301,7 +301,7 @@ describe('Musics component', () => {
 
       render(<Musics musics={longTitleMusic} />);
 
-      expect(screen.getByText(/This is a very long music title/)).toBeInTheDocument();
+      expect(screen.getAllByText(/This is a very long music title/)[0]).toBeInTheDocument();
     });
 
     it('should handle very long artist name', () => {
@@ -333,8 +333,8 @@ describe('Musics component', () => {
 
       render(<Musics musics={manyMusics} />);
 
-      expect(screen.getByText('Album 0')).toBeInTheDocument();
-      expect(screen.getByText('Album 49')).toBeInTheDocument();
+      expect(screen.getAllByText('Album 0')[0]).toBeInTheDocument();
+      expect(screen.getAllByText('Album 49')[0]).toBeInTheDocument();
       const rows = screen.getAllByRole('row');
       expect(rows).toHaveLength(51); // header + 50 musics
     });
@@ -441,7 +441,7 @@ describe('Musics component', () => {
       render(<Musics musics={mockMusics} />);
 
       const editButtons = screen.getAllByRole('link', { name: /edit/i });
-      expect(editButtons).toHaveLength(mockMusics.length);
+      expect(editButtons).toHaveLength(mockMusics.length * 2);
 
       editButtons.forEach((btn: HTMLElement) => {
         expect(btn).toHaveAttribute('aria-label', 'Edit');
@@ -452,7 +452,7 @@ describe('Musics component', () => {
       render(<Musics musics={mockMusics} />);
 
       const deleteButtons = screen.getAllByRole('button', { name: /delete/i });
-      expect(deleteButtons).toHaveLength(mockMusics.length);
+      expect(deleteButtons).toHaveLength(mockMusics.length * 2);
 
       deleteButtons.forEach((btn: HTMLElement) => {
         expect(btn).toHaveAttribute('aria-label', 'Delete');

--- a/MediaSet.Remix/app/routes/$entity._index/components/musics.tsx
+++ b/MediaSet.Remix/app/routes/$entity._index/components/musics.tsx
@@ -21,7 +21,47 @@ export default function Musics({ musics, apiUrl, orderBy = 'title:asc', searchTe
 
   return (
     <>
-      <table className="text-left w-full">
+      <div className="md:hidden flex flex-col divide-y divide-slate-700">
+        {musics.map((music) => (
+          <div key={music.id} className="flex flex-row items-center gap-3 py-2 px-2 dark:hover:bg-zinc-800">
+            {music.coverImage && (
+              <div className="flex-shrink-0">
+                <ImageDisplay
+                  imageData={music.coverImage}
+                  alt={`${music.title} cover`}
+                  entityType={Entity.Musics}
+                  entityId={music.id}
+                  apiUrl={apiUrl}
+                  size="xsmall"
+                />
+              </div>
+            )}
+            <div className="flex-1 min-w-0">
+              <Link to={`/musics/${music.id}`} className="font-medium block truncate">
+                {music.title}
+              </Link>
+              <div className="text-xs text-gray-400 truncate">
+                {[music.artist, music.format].filter(Boolean).join(' · ')}
+              </div>
+            </div>
+            <div className="flex flex-row gap-3 flex-shrink-0">
+              <Link to={`/musics/${music.id}/edit`} aria-label="Edit" title="Edit">
+                <Pencil size={18} />
+              </Link>
+              <button
+                onClick={() => setDeleteDialogState({ isOpen: true, music })}
+                className="link"
+                type="button"
+                aria-label="Delete"
+                title="Delete"
+              >
+                <Trash2 size={18} />
+              </button>
+            </div>
+          </div>
+        ))}
+      </div>
+      <table className="hidden md:table text-left w-full">
         <thead className="dark:bg-zinc-700 border-b-2 border-slate-600">
           <tr>
             <th className="hidden md:table-cell pl-2 p-1 border-r border-slate-800">Cover</th>


### PR DESCRIPTION
## Summary

- Adds a responsive card list view for Books, Movies, Games, and Music entity lists on mobile (below `md` breakpoint)
- Each card shows: cover thumbnail (when available), title as a link, key secondary info in muted text, and edit/delete actions
- Desktop table view is unchanged
- Secondary info per entity: Books (authors · format), Movies (format · runtime · TV Show), Games (platform · format), Music (artist · format)

Closes #517

## Test plan

- [x] View entity lists on a mobile viewport (< 768px) — cards should render with thumbnail, title, and secondary info
- [x] View entity lists on desktop (≥ 768px) — table should render as before
- [x] Verify cover image appears in card when an entity has one, and is hidden when it doesn't
- [x] Confirm edit and delete actions work from the card view
- [x] All 100 frontend unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)