### PR TITLE
feat(images): add orphaned image cleanup closes #523

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -171,6 +171,10 @@ dotnet_naming_rule.non_field_members_should_be_pascal_case.severity = error
 dotnet_naming_rule.non_field_members_should_be_pascal_case.symbols = non_field_members
 dotnet_naming_rule.non_field_members_should_be_pascal_case.style = pascal_case
 
+dotnet_naming_rule.const_fields_should_be_pascal_case.severity = error
+dotnet_naming_rule.const_fields_should_be_pascal_case.symbols = const_fields
+dotnet_naming_rule.const_fields_should_be_pascal_case.style = pascal_case
+
 dotnet_naming_rule.private_or_internal_field_should_be_underscore_camel_case.severity = error
 dotnet_naming_rule.private_or_internal_field_should_be_underscore_camel_case.symbols = private_or_internal_field
 dotnet_naming_rule.private_or_internal_field_should_be_underscore_camel_case.style = underscore_camel_case
@@ -178,11 +182,15 @@ dotnet_naming_rule.private_or_internal_field_should_be_underscore_camel_case.sty
 # Symbol specifications
 dotnet_naming_symbols.interface.applicable_kinds = interface
 dotnet_naming_symbols.interface.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
-dotnet_naming_symbols.interface.required_modifiers = 
+dotnet_naming_symbols.interface.required_modifiers =
+
+dotnet_naming_symbols.const_fields.applicable_kinds = field
+dotnet_naming_symbols.const_fields.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.const_fields.required_modifiers = const
 
 dotnet_naming_symbols.private_or_internal_field.applicable_kinds = field
 dotnet_naming_symbols.private_or_internal_field.applicable_accessibilities = internal, private, private_protected
-dotnet_naming_symbols.private_or_internal_field.required_modifiers = 
+dotnet_naming_symbols.private_or_internal_field.required_modifiers =
 
 dotnet_naming_symbols.types.applicable_kinds = class, struct, interface, enum
 dotnet_naming_symbols.types.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected

--- a/MediaSet.Api.Tests/Features/Images/Endpoints/ImagesApiTests.cs
+++ b/MediaSet.Api.Tests/Features/Images/Endpoints/ImagesApiTests.cs
@@ -1,0 +1,88 @@
+using MediaSet.Api.Features.Images.Services;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using NUnit.Framework;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace MediaSet.Api.Tests.Features.Images.Endpoints;
+
+[TestFixture]
+public class ImagesApiTests : IntegrationTestBase
+{
+    private WebApplicationFactory<Program> _factory = null!;
+    private HttpClient _client = null!;
+    private Mock<IImageManagementService> _imageManagementServiceMock = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _imageManagementServiceMock = new Mock<IImageManagementService>();
+
+        _factory = CreateWebApplicationFactory()
+            .WithWebHostBuilder(builder =>
+            {
+                builder.ConfigureServices(services =>
+                {
+                    var descriptor = services.SingleOrDefault(
+                        d => d.ServiceType == typeof(IImageManagementService));
+                    if (descriptor != null)
+                    {
+                        services.Remove(descriptor);
+                    }
+
+                    services.AddScoped<IImageManagementService>(_ => _imageManagementServiceMock.Object);
+                });
+            });
+
+        _client = _factory.CreateClient();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _client?.Dispose();
+        _factory?.Dispose();
+    }
+
+    [Test]
+    public async Task DeleteOrphanedImages_ShouldReturnOk_WithDeletedCount()
+    {
+        // Arrange
+        _imageManagementServiceMock.Setup(s => s.DeleteOrphanedImagesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(3);
+
+        // Act
+        var response = await _client.DeleteAsync("/images/orphaned");
+        var result = await response.Content.ReadFromJsonAsync<Dictionary<string, int>>();
+
+        // Assert
+        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK));
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result!["deleted"], Is.EqualTo(3));
+        _imageManagementServiceMock.Verify(s => s.DeleteOrphanedImagesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Test]
+    public async Task DeleteOrphanedImages_ShouldReturnZero_WhenNoOrphanedFiles()
+    {
+        // Arrange
+        _imageManagementServiceMock.Setup(s => s.DeleteOrphanedImagesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(0);
+
+        // Act
+        var response = await _client.DeleteAsync("/images/orphaned");
+        var result = await response.Content.ReadFromJsonAsync<Dictionary<string, int>>();
+
+        // Assert
+        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK));
+        Assert.That(result!["deleted"], Is.EqualTo(0));
+        _imageManagementServiceMock.Verify(s => s.DeleteOrphanedImagesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+}

--- a/MediaSet.Api.Tests/Features/Images/Services/ImageManagementServiceTests.cs
+++ b/MediaSet.Api.Tests/Features/Images/Services/ImageManagementServiceTests.cs
@@ -1,0 +1,150 @@
+using MediaSet.Api.Features.Images.Services;
+using MediaSet.Api.Infrastructure.Caching;
+using MediaSet.Api.Infrastructure.DataAccess;
+using MediaSet.Api.Infrastructure.Storage;
+using MediaSet.Api.Shared.Models;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NUnit.Framework;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace MediaSet.Api.Tests.Features.Images.Services;
+
+[TestFixture]
+public class ImageManagementServiceTests
+{
+    private Mock<IImageStorageProvider> _storageProviderMock = null!;
+    private Mock<IEntityService<Book>> _bookServiceMock = null!;
+    private Mock<IEntityService<Movie>> _movieServiceMock = null!;
+    private Mock<IEntityService<Game>> _gameServiceMock = null!;
+    private Mock<IEntityService<Music>> _musicServiceMock = null!;
+    private Mock<ICacheService> _cacheServiceMock = null!;
+    private Mock<ILogger<ImageManagementService>> _loggerMock = null!;
+    private ImageManagementService _imageManagementService = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _storageProviderMock = new Mock<IImageStorageProvider>();
+        _bookServiceMock = new Mock<IEntityService<Book>>();
+        _movieServiceMock = new Mock<IEntityService<Movie>>();
+        _gameServiceMock = new Mock<IEntityService<Game>>();
+        _musicServiceMock = new Mock<IEntityService<Music>>();
+        _cacheServiceMock = new Mock<ICacheService>();
+        _loggerMock = new Mock<ILogger<ImageManagementService>>();
+
+        _storageProviderMock.Setup(s => s.ListFiles())
+            .Returns(new List<(string, long)>());
+
+        _bookServiceMock.Setup(s => s.GetListAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<Book>());
+        _movieServiceMock.Setup(s => s.GetListAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<Movie>());
+        _gameServiceMock.Setup(s => s.GetListAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<Game>());
+        _musicServiceMock.Setup(s => s.GetListAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<Music>());
+
+        _imageManagementService = new ImageManagementService(
+            _storageProviderMock.Object,
+            _bookServiceMock.Object,
+            _movieServiceMock.Object,
+            _gameServiceMock.Object,
+            _musicServiceMock.Object,
+            _cacheServiceMock.Object,
+            _loggerMock.Object);
+    }
+
+    [Test]
+    public async Task DeleteOrphanedImagesAsync_ShouldReturnZero_WhenNoOrphanedFiles()
+    {
+        // Act
+        var result = await _imageManagementService.DeleteOrphanedImagesAsync();
+
+        // Assert
+        Assert.That(result, Is.EqualTo(0));
+        _storageProviderMock.Verify(s => s.DeleteImage(It.IsAny<string>()), Times.Never);
+    }
+
+    [Test]
+    public async Task DeleteOrphanedImagesAsync_ShouldDeleteOrphanedFiles_AndReturnCount()
+    {
+        // Arrange
+        _storageProviderMock.Setup(s => s.ListFiles())
+            .Returns(new List<(string RelativePath, long SizeBytes)>
+            {
+                ("books/file1.jpg", 1000),
+                ("books/orphaned.jpg", 500),
+            });
+
+        var book = new Book { Id = "1", Title = "Test", Format = "Paperback", CoverImage = new Image { FilePath = "books/file1.jpg" } };
+        _bookServiceMock.Setup(s => s.GetListAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<Book> { book });
+
+        // Act
+        var result = await _imageManagementService.DeleteOrphanedImagesAsync();
+
+        // Assert
+        Assert.That(result, Is.EqualTo(1));
+        _storageProviderMock.Verify(s => s.DeleteImage("books/orphaned.jpg"), Times.Once);
+        _storageProviderMock.Verify(s => s.DeleteImage("books/file1.jpg"), Times.Never);
+    }
+
+    [Test]
+    public async Task DeleteOrphanedImagesAsync_ShouldInvalidateImageStatsCache()
+    {
+        // Act
+        await _imageManagementService.DeleteOrphanedImagesAsync();
+
+        // Assert
+        _cacheServiceMock.Verify(c => c.RemoveAsync("image-stats"), Times.Once);
+    }
+
+    [Test]
+    public async Task DeleteOrphanedImagesAsync_ShouldDeleteMultipleOrphanedFiles()
+    {
+        // Arrange
+        _storageProviderMock.Setup(s => s.ListFiles())
+            .Returns(new List<(string RelativePath, long SizeBytes)>
+            {
+                ("books/orphaned1.jpg", 500),
+                ("books/orphaned2.jpg", 300),
+                ("movies/orphaned3.jpg", 700),
+            });
+
+        // Act
+        var result = await _imageManagementService.DeleteOrphanedImagesAsync();
+
+        // Assert
+        Assert.That(result, Is.EqualTo(3));
+        _storageProviderMock.Verify(s => s.DeleteImage(It.IsAny<string>()), Times.Exactly(3));
+    }
+
+    [Test]
+    public async Task DeleteOrphanedImagesAsync_ShouldNotDeleteReferencedFiles()
+    {
+        // Arrange
+        _storageProviderMock.Setup(s => s.ListFiles())
+            .Returns(new List<(string RelativePath, long SizeBytes)>
+            {
+                ("books/file1.jpg", 1000),
+                ("movies/file2.jpg", 2000),
+            });
+
+        var book = new Book { Id = "1", Title = "Book", Format = "Paperback", CoverImage = new Image { FilePath = "books/file1.jpg" } };
+        var movie = new Movie { Id = "2", Title = "Movie", Format = "Blu-ray", CoverImage = new Image { FilePath = "movies/file2.jpg" } };
+        _bookServiceMock.Setup(s => s.GetListAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<Book> { book });
+        _movieServiceMock.Setup(s => s.GetListAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<Movie> { movie });
+
+        // Act
+        var result = await _imageManagementService.DeleteOrphanedImagesAsync();
+
+        // Assert
+        Assert.That(result, Is.EqualTo(0));
+        _storageProviderMock.Verify(s => s.DeleteImage(It.IsAny<string>()), Times.Never);
+    }
+}

--- a/MediaSet.Api.Tests/Features/Statistics/Endpoints/StatsApiTests.cs
+++ b/MediaSet.Api.Tests/Features/Statistics/Endpoints/StatsApiTests.cs
@@ -4,6 +4,7 @@ using NUnit.Framework;
 using Moq;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.DependencyInjection;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
@@ -21,18 +22,19 @@ public class StatsApiTests : IntegrationTestBase
     private WebApplicationFactory<Program> _factory = null!;
     private HttpClient _client = null!;
     private Mock<IStatsService> _statsServiceMock = null!;
+    private Mock<IImageStatsService> _imageStatsServiceMock = null!;
 
     [SetUp]
     public void Setup()
     {
         _statsServiceMock = new Mock<IStatsService>();
+        _imageStatsServiceMock = new Mock<IImageStatsService>();
 
         _factory = CreateWebApplicationFactory()
             .WithWebHostBuilder(builder =>
             {
                 builder.ConfigureServices(services =>
                 {
-                    // Remove existing StatsService registration
                     var statsServiceDescriptor = services.SingleOrDefault(
                         d => d.ServiceType == typeof(IStatsService));
                     if (statsServiceDescriptor != null)
@@ -40,8 +42,15 @@ public class StatsApiTests : IntegrationTestBase
                         services.Remove(statsServiceDescriptor);
                     }
 
-                    // Add mock service
+                    var imageStatsServiceDescriptor = services.SingleOrDefault(
+                        d => d.ServiceType == typeof(IImageStatsService));
+                    if (imageStatsServiceDescriptor != null)
+                    {
+                        services.Remove(imageStatsServiceDescriptor);
+                    }
+
                     services.AddScoped<IStatsService>(_ => _statsServiceMock.Object);
+                    services.AddScoped<IImageStatsService>(_ => _imageStatsServiceMock.Object);
                 });
             });
 
@@ -485,6 +494,47 @@ public class StatsApiTests : IntegrationTestBase
         Assert.That(result, Is.Not.Null);
         Assert.That(result!.MovieStats.TotalTvSeries, Is.EqualTo(0));
         _statsServiceMock.Verify(s => s.GetMediaStatsAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Test]
+    public async Task GetImageStats_ShouldReturnOk_WhenStatsExist()
+    {
+        // Arrange
+        var expectedStats = new ApiModels.ImageStats(
+            TotalFiles: 5,
+            TotalSizeBytes: 10240,
+            FilesByEntityType: new Dictionary<string, int> { { "books", 5 } },
+            SizeByEntityType: new Dictionary<string, long> { { "books", 10240 } },
+            BrokenLinks: new List<ApiModels.BrokenImageLink>(),
+            OrphanedFiles: new List<ApiModels.OrphanedImageFile>(),
+            LastUpdated: DateTime.UtcNow
+        );
+        _imageStatsServiceMock.Setup(s => s.GetImageStatsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedStats);
+
+        // Act
+        var response = await _client.GetAsync("/stats/images");
+        var result = await response.Content.ReadFromJsonAsync<ApiModels.ImageStats>();
+
+        // Assert
+        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK));
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result!.TotalFiles, Is.EqualTo(5));
+        _imageStatsServiceMock.Verify(s => s.GetImageStatsAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Test]
+    public async Task GetImageStats_ShouldReturnNoContent_WhenStatsUnavailable()
+    {
+        // Arrange
+        _imageStatsServiceMock.Setup(s => s.GetImageStatsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ApiModels.ImageStats?)null);
+
+        // Act
+        var response = await _client.GetAsync("/stats/images");
+
+        // Assert
+        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.NoContent));
     }
 
     [Test]

--- a/MediaSet.Api/Features/Images/Endpoints/ImagesApi.cs
+++ b/MediaSet.Api/Features/Images/Endpoints/ImagesApi.cs
@@ -1,0 +1,23 @@
+using MediaSet.Api.Features.Images.Services;
+
+namespace MediaSet.Api.Features.Images.Endpoints;
+
+internal static class ImagesApi
+{
+    public static RouteGroupBuilder MapImages(this IEndpointRouteBuilder routes)
+    {
+        var logger = ((WebApplication)routes).Logger;
+        var group = routes.MapGroup("/images");
+
+        group.WithTags("Images");
+
+        group.MapDelete("/orphaned", async (IImageManagementService imageManagementService, CancellationToken cancellationToken) =>
+        {
+            logger.LogInformation("Deleting orphaned images");
+            var count = await imageManagementService.DeleteOrphanedImagesAsync(cancellationToken);
+            return Results.Ok(new { deleted = count });
+        });
+
+        return group;
+    }
+}

--- a/MediaSet.Api/Features/Images/Services/IImageManagementService.cs
+++ b/MediaSet.Api/Features/Images/Services/IImageManagementService.cs
@@ -1,0 +1,6 @@
+namespace MediaSet.Api.Features.Images.Services;
+
+public interface IImageManagementService
+{
+    Task<int> DeleteOrphanedImagesAsync(CancellationToken cancellationToken = default);
+}

--- a/MediaSet.Api/Features/Images/Services/ImageManagementService.cs
+++ b/MediaSet.Api/Features/Images/Services/ImageManagementService.cs
@@ -1,0 +1,82 @@
+using MediaSet.Api.Infrastructure.Caching;
+using MediaSet.Api.Infrastructure.DataAccess;
+using MediaSet.Api.Infrastructure.Storage;
+using MediaSet.Api.Shared.Models;
+using Serilog;
+using SerilogTracing;
+
+namespace MediaSet.Api.Features.Images.Services;
+
+public class ImageManagementService : IImageManagementService
+{
+    private const string ImageStatsCacheKey = "image-stats";
+
+    private readonly IImageStorageProvider storageProvider;
+    private readonly IEntityService<Book> bookService;
+    private readonly IEntityService<Movie> movieService;
+    private readonly IEntityService<Game> gameService;
+    private readonly IEntityService<Music> musicService;
+    private readonly ICacheService cacheService;
+    private readonly ILogger<ImageManagementService> logger;
+
+    public ImageManagementService(
+        IImageStorageProvider _storageProvider,
+        IEntityService<Book> _bookService,
+        IEntityService<Movie> _movieService,
+        IEntityService<Game> _gameService,
+        IEntityService<Music> _musicService,
+        ICacheService _cacheService,
+        ILogger<ImageManagementService> _logger)
+    {
+        storageProvider = _storageProvider;
+        bookService = _bookService;
+        movieService = _movieService;
+        gameService = _gameService;
+        musicService = _musicService;
+        cacheService = _cacheService;
+        logger = _logger;
+    }
+
+    public async Task<int> DeleteOrphanedImagesAsync(CancellationToken cancellationToken = default)
+    {
+        using var activity = Log.Logger.StartActivity("DeleteOrphanedImages");
+
+        var allFiles = storageProvider.ListFiles().ToList();
+
+        var bookTask = bookService.GetListAsync(cancellationToken);
+        var movieTask = movieService.GetListAsync(cancellationToken);
+        var gameTask = gameService.GetListAsync(cancellationToken);
+        var musicTask = musicService.GetListAsync(cancellationToken);
+        await Task.WhenAll(bookTask, movieTask, gameTask, musicTask);
+
+        var referencedPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var allEntities = bookTask.Result.Cast<IEntity>()
+            .Concat(movieTask.Result.Cast<IEntity>())
+            .Concat(gameTask.Result.Cast<IEntity>())
+            .Concat(musicTask.Result.Cast<IEntity>());
+
+        foreach (var entity in allEntities)
+        {
+            if (entity.CoverImage != null && !string.IsNullOrEmpty(entity.CoverImage.FilePath))
+            {
+                referencedPaths.Add(entity.CoverImage.FilePath);
+            }
+        }
+
+        var orphanedFiles = allFiles
+            .Where(f => !referencedPaths.Contains(f.RelativePath))
+            .ToList();
+
+        foreach (var (relativePath, _) in orphanedFiles)
+        {
+            logger.LogInformation("Deleting orphaned image file: {FilePath}", relativePath);
+            storageProvider.DeleteImage(relativePath);
+        }
+
+        await cacheService.RemoveAsync(ImageStatsCacheKey);
+
+        logger.LogInformation("Deleted {Count} orphaned image files and invalidated image stats cache", orphanedFiles.Count);
+
+        return orphanedFiles.Count;
+    }
+}

--- a/MediaSet.Api/Program.cs
+++ b/MediaSet.Api/Program.cs
@@ -10,6 +10,7 @@ using MediaSet.Api.Features.Lookup.Endpoints;
 using MediaSet.Api.Features.Config.Endpoints;
 using MediaSet.Api.Features.Metadata.Endpoints;
 using MediaSet.Api.Features.Health.Endpoints;
+using MediaSet.Api.Features.Images.Endpoints;
 using MediaSet.Api.Features.Statistics.Endpoints;
 
 using MediaSet.Api.Features.Images.Services;
@@ -224,6 +225,9 @@ builder.Services.AddSingleton<IVersionService, VersionService>();
 // Configure image stats service
 builder.Services.AddScoped<IImageStatsService, ImageStatsService>();
 
+// Configure image management service
+builder.Services.AddScoped<IImageManagementService, ImageManagementService>();
+
 // Configure background image lookup service
 builder.Services.Configure<BackgroundImageLookupConfiguration>(
     builder.Configuration.GetSection(nameof(BackgroundImageLookupConfiguration)));
@@ -319,6 +323,7 @@ app.MapEntity<Game>();
 app.MapEntity<Music>();
 app.MapMetadata();
 app.MapStats();
+app.MapImages();
 
 if (openLibraryConfig.Exists() || tmdbConfig.Exists() || igdbConfig.Exists())
 {

--- a/MediaSet.Remix/app/api/image-management-data.test.ts
+++ b/MediaSet.Remix/app/api/image-management-data.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const { mockApiFetch } = vi.hoisted(() => ({
+  mockApiFetch: vi.fn(),
+}));
+
+vi.mock('~/utils/apiFetch.server', () => ({
+  apiFetch: mockApiFetch,
+}));
+
+vi.mock('~/utils/serverLogger', () => ({
+  serverLogger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+import { deleteOrphanedImages } from '~/api/image-management-data';
+
+describe('image-management-data.ts', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockApiFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ deleted: 0 }),
+    });
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe('deleteOrphanedImages', () => {
+    it('should return the count of deleted files', async () => {
+      mockApiFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ deleted: 5 }),
+      });
+
+      const result = await deleteOrphanedImages();
+
+      expect(result).toEqual({ deleted: 5 });
+      expect(mockApiFetch).toHaveBeenCalledWith(expect.stringContaining('/images/orphaned'), { method: 'DELETE' });
+    });
+
+    it('should return zero when no orphaned files exist', async () => {
+      mockApiFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ deleted: 0 }),
+      });
+
+      const result = await deleteOrphanedImages();
+
+      expect(result).toEqual({ deleted: 0 });
+    });
+
+    it('should throw Response on non-ok status', async () => {
+      mockApiFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        json: async () => null,
+      });
+
+      await expect(deleteOrphanedImages()).rejects.toBeInstanceOf(Response);
+    });
+
+    it('should throw on network error', async () => {
+      mockApiFetch.mockRejectedValueOnce(new Error('Network error'));
+
+      await expect(deleteOrphanedImages()).rejects.toThrow('Network error');
+    });
+  });
+});

--- a/MediaSet.Remix/app/api/image-management-data.ts
+++ b/MediaSet.Remix/app/api/image-management-data.ts
@@ -1,0 +1,18 @@
+import { baseUrl } from '~/constants.server';
+import { serverLogger } from '~/utils/serverLogger';
+import { apiFetch } from '~/utils/apiFetch.server';
+
+export async function deleteOrphanedImages(): Promise<{ deleted: number }> {
+  try {
+    const response = await apiFetch(`${baseUrl}/images/orphaned`, { method: 'DELETE' });
+    if (!response.ok) {
+      serverLogger.error('Failed to delete orphaned images', { status: response.status });
+      throw new Response('Error deleting orphaned images', { status: 500 });
+    }
+    return (await response.json()) as { deleted: number };
+  } catch (error) {
+    if (error instanceof Response) throw error;
+    serverLogger.error('Error deleting orphaned images', { error: String(error) });
+    throw error;
+  }
+}

--- a/MediaSet.Remix/app/root.tsx
+++ b/MediaSet.Remix/app/root.tsx
@@ -69,9 +69,8 @@ function Header() {
 
           {/* Tools dropdown */}
           <div ref={toolsRef} className="relative">
-            {/* className="p-3 flex gap-2 items-center rounded-lg hover:dark:bg-zinc-600" */}
             <button
-              className="p-3 flex gap-2 items-center rounded-lg secondary"
+              className="p-3 flex gap-2 items-center rounded-lg tertiary"
               onClick={() => setToolsOpen(!toolsOpen)}
               aria-label="Tools"
               aria-expanded={toolsOpen}

--- a/MediaSet.Remix/app/routes/image-stats.tsx
+++ b/MediaSet.Remix/app/routes/image-stats.tsx
@@ -1,8 +1,9 @@
-import { type MetaFunction } from '@remix-run/node';
-import { useLoaderData, Link } from '@remix-run/react';
+import { type ActionFunctionArgs, type MetaFunction } from '@remix-run/node';
+import { useLoaderData, Link, Form, useNavigation } from '@remix-run/react';
 import { getImageStats } from '~/api/image-stats-data';
+import { deleteOrphanedImages } from '~/api/image-management-data';
 import StatCard from '~/components/stat-card';
-import { HardDrive, Files, AlertTriangle, Link2Off } from 'lucide-react';
+import { HardDrive, Files, AlertTriangle, Link2Off, Trash2 } from 'lucide-react';
 
 export const meta: MetaFunction = () => {
   return [
@@ -16,6 +17,15 @@ export const loader = async () => {
   return { stats };
 };
 
+export const action = async ({ request }: ActionFunctionArgs) => {
+  const formData = await request.formData();
+  const intent = formData.get('intent');
+  if (intent === 'delete-orphaned') {
+    await deleteOrphanedImages();
+  }
+  return null;
+};
+
 function formatBytes(bytes: number): string {
   if (bytes === 0) return '0 B';
   const units = ['B', 'KB', 'MB', 'GB', 'TB'];
@@ -25,6 +35,8 @@ function formatBytes(bytes: number): string {
 
 export default function ImageStatsPage() {
   const { stats } = useLoaderData<typeof loader>();
+  const navigation = useNavigation();
+  const isDeleting = navigation.state === 'submitting' && navigation.formData?.get('intent') === 'delete-orphaned';
 
   if (!stats) {
     return (
@@ -148,10 +160,25 @@ export default function ImageStatsPage() {
       {/* Orphaned Files */}
       {stats.orphanedFiles.length > 0 && (
         <div>
-          <h2 className="mb-4 text-xl font-semibold text-white">
-            <span className="text-yellow-400">Orphaned Files</span>
-            <span className="ml-2 text-sm font-normal text-zinc-400">— files on disk not referenced by any entity</span>
-          </h2>
+          <div className="mb-4 flex items-center justify-between">
+            <h2 className="text-xl font-semibold text-white">
+              <span className="text-yellow-400">Orphaned Files</span>
+              <span className="ml-2 text-sm font-normal text-zinc-400">
+                — files on disk not referenced by any entity
+              </span>
+            </h2>
+            <Form method="post">
+              <input type="hidden" name="intent" value="delete-orphaned" />
+              <button
+                type="submit"
+                disabled={isDeleting}
+                className="flex items-center gap-2 rounded-md bg-yellow-600 px-3 py-2 text-sm font-medium text-white hover:bg-yellow-700 disabled:opacity-50"
+              >
+                <Trash2 className="h-4 w-4" />
+                {isDeleting ? 'Cleaning up...' : 'Clean Up Orphaned Files'}
+              </button>
+            </Form>
+          </div>
           <div className="overflow-x-auto rounded-lg border border-zinc-700">
             <table className="w-full text-sm">
               <thead className="bg-zinc-800 text-left text-zinc-400">

--- a/MediaSet.Remix/app/tailwind.css
+++ b/MediaSet.Remix/app/tailwind.css
@@ -21,7 +21,12 @@
     @apply text-gray-400 opacity-100;
   }
 
-  button:not([class~='link']):not([class~='image-button']):not([class~='text-icon']) {
+  button
+    :not([class~='link'])
+    :not([class~='image-button'])
+    :not([class~='text-icon'])
+    :not([class~='secondary'])
+    :not([class~='tertiary']) {
     @apply px-3 py-1 dark:text-slate-200 dark:bg-blue-600 dark:hover:bg-blue-500 dark:disabled:bg-slate-900 dark:disabled:text-slate-500 rounded bg-white transition-colors;
   }
 


### PR DESCRIPTION
## Summary

- Adds `ImageManagementService` in `Features/Images` with `DeleteOrphanedImagesAsync` — finds files on disk not referenced by any entity, deletes them, and invalidates the image-stats cache
- Adds `DELETE /images/orphaned` endpoint via a new `ImagesApi` route group, keeping image operations out of the stats feature
- Adds a **Clean Up Orphaned Files** button to the image-stats page that calls the new endpoint via a Remix action and reloads the stats automatically
- Adds `image-management-data.ts` as the dedicated frontend data file for image management operations
- Fixes `.editorconfig` to add a `const_fields` PascalCase naming rule, preventing `const` fields from incorrectly matching the private field underscore rule (IDE1006)

## Test plan

- [x] Verify `DELETE /images/orphaned` deletes orphaned files and returns `{ deleted: N }`
- [x] Verify image-stats cache is invalidated after cleanup (stats page reloads with updated counts)
- [x] Verify the Clean Up Orphaned Files button appears only when orphaned files exist and shows a loading state while submitting
- [x] Verify referenced images are not deleted
- [x] Run backend tests: `dotnet test MediaSet.Api.Tests/MediaSet.Api.Tests.csproj`
- [x] Run frontend tests: `cd MediaSet.Remix && npm test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)