### PR TITLE
fix(lookup,ui): fix music title search and button styles

### DIFF
--- a/MediaSet.Api/Infrastructure/Lookup/Clients/MusicBrainz/MusicBrainzClient.cs
+++ b/MediaSet.Api/Infrastructure/Lookup/Clients/MusicBrainz/MusicBrainzClient.cs
@@ -159,7 +159,7 @@ public class MusicBrainzClient : IMusicBrainzClient
 
             var encodedTitle = Uri.EscapeDataString(title);
             var response = await _httpClient.GetAsync(
-                $"ws/2/release/?query=release:{encodedTitle}&limit=10&fmt=json",
+                $"ws/2/release/?query={encodedTitle}&limit=10&fmt=json",
                 cancellationToken);
 
             _lastRequestTime = DateTime.UtcNow;

--- a/MediaSet.Remix/app/tailwind.css
+++ b/MediaSet.Remix/app/tailwind.css
@@ -21,12 +21,13 @@
     @apply text-gray-400 opacity-100;
   }
 
-  button
-    :not([class~='link'])
-    :not([class~='image-button'])
-    :not([class~='text-icon'])
-    :not([class~='secondary'])
-    :not([class~='tertiary']) {
+  button:not(
+    [class~='link'],
+    [class~='image-button'],
+    [class~='text-icon'],
+    [class~='secondary'],
+    [class~='tertiary']
+  ) {
     @apply px-3 py-1 dark:text-slate-200 dark:bg-blue-600 dark:hover:bg-blue-500 dark:disabled:bg-slate-900 dark:disabled:text-slate-500 rounded bg-white transition-colors;
   }
 


### PR DESCRIPTION
## Summary

- Remove `release:` Lucene field qualifier from MusicBrainz title search query — it caused multi-word titles to be parsed as separate terms, producing incorrect relevance ranking. Plain text search matches MusicBrainz's own search behavior.
- Fix global button CSS selector in `tailwind.css` which used descendant combinators (whitespace between `button` and `:not()`) instead of a compound pseudo-class, preventing the default blue style from applying to unstyled buttons. Rewrote as a single `:not()` with a comma-separated selector list.

## Test plan

- [x] Search for a multi-word music album title (e.g. "Don't Look Back") via the lookup endpoint and verify expected results appear
- [x] Verify unstyled buttons render with blue background on the Add entity pages
- [x] All 1024 frontend tests pass
- [x] All 533 backend tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)