### PR TITLE
feat(search): add paged search endpoint and paginated list view

### DIFF
--- a/MediaSet.Api/Features/Entities/Endpoints/EntityApi.cs
+++ b/MediaSet.Api/Features/Entities/Endpoints/EntityApi.cs
@@ -42,6 +42,22 @@ internal static class EntityApi
             }
         });
 
+        group.MapGet("/pagedsearch", async Task<Results<Ok<PagedResult<TEntity>>, BadRequest<string>>> (IEntityService<TEntity> entityService, string searchText, string orderBy, int page = 1, int pageSize = 75, CancellationToken cancellationToken = default) =>
+        {
+            try
+            {
+                logger.LogInformation("Paged searching {entityType} with query '{searchText}', orderBy {orderBy}, page {page}, pageSize {pageSize}", entityType, searchText, orderBy, page, pageSize);
+                var result = await entityService.PagedSearchAsync(searchText, orderBy, page, pageSize, cancellationToken);
+                logger.LogInformation("Paged search returned {count}/{total} {entityType}", result.Items.Count(), result.TotalCount, entityType);
+                return TypedResults.Ok(result);
+            }
+            catch (ArgumentException ex)
+            {
+                logger.LogWarning("Invalid orderBy field for {entityType}: {message}", entityType, ex.Message);
+                return TypedResults.BadRequest(ex.Message);
+            }
+        });
+
         group.MapGet("/{id}", async Task<Results<Ok<TEntity>, NotFound>> (IEntityService<TEntity> entityService, string id, CancellationToken cancellationToken) =>
         {
             logger.LogInformation("Fetching {entityType} by id {id}", entityType, id);

--- a/MediaSet.Api/Infrastructure/DataAccess/EntityService.cs
+++ b/MediaSet.Api/Infrastructure/DataAccess/EntityService.cs
@@ -68,6 +68,55 @@ public class EntityService<TEntity> : IEntityService<TEntity> where TEntity : IE
         return await cursor.ToListAsync(cancellationToken);
     }
 
+    public async Task<PagedResult<TEntity>> PagedSearchAsync(string searchText, string orderBy, int page, int pageSize, CancellationToken cancellationToken = default)
+    {
+        using var activity = Log.Logger.StartActivity("PagedSearch {EntityType}", new { EntityType = entityTypeName, searchText, orderBy, page, pageSize });
+
+        string orderByField = nameof(IEntity.Title);
+        bool orderByAscending = true;
+
+        if (!string.IsNullOrWhiteSpace(orderBy))
+        {
+            var orderByArgs = orderBy.Split(":");
+            var requestedField = orderByArgs[0];
+
+            if (!string.IsNullOrWhiteSpace(requestedField))
+            {
+                var property = typeof(TEntity).GetProperty(requestedField, BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.Instance);
+                if (property == null)
+                {
+                    throw new ArgumentException($"Invalid order by field '{requestedField}' for entity type '{entityTypeName}'.");
+                }
+                orderByField = property.Name;
+            }
+
+            if (orderByArgs.Length >= 2 && !string.IsNullOrWhiteSpace(orderByArgs[1]))
+            {
+                orderByAscending = orderByArgs[1].ToLower() == "asc";
+            }
+        }
+
+        var searchPattern = Regex.Escape(searchText);
+        var filter = Builders<TEntity>.Filter.Regex(entity => entity.Title, new BsonRegularExpression(searchPattern, "i"));
+        var sort = orderByAscending
+            ? Builders<TEntity>.Sort.Ascending(orderByField)
+            : Builders<TEntity>.Sort.Descending(orderByField);
+
+        var totalCount = await entityCollection.CountDocumentsAsync(filter, cancellationToken: cancellationToken);
+
+        var findOptions = new FindOptions<TEntity>
+        {
+            Sort = sort,
+            Skip = (page - 1) * pageSize,
+            Limit = pageSize
+        };
+
+        using var cursor = await entityCollection.FindAsync(filter, findOptions, cancellationToken);
+        var items = await cursor.ToListAsync(cancellationToken);
+
+        return new PagedResult<TEntity>(items, totalCount, page, pageSize);
+    }
+
     public async Task<IEnumerable<TEntity>> GetListAsync(CancellationToken cancellationToken = default)
     {
         using var activity = Log.Logger.StartActivity("GetList {EntityType}", new { EntityType = entityTypeName });

--- a/MediaSet.Api/Infrastructure/DataAccess/IEntityService.cs
+++ b/MediaSet.Api/Infrastructure/DataAccess/IEntityService.cs
@@ -6,6 +6,7 @@ namespace MediaSet.Api.Infrastructure.DataAccess;
 public interface IEntityService<TEntity> where TEntity : IEntity
 {
     Task<IEnumerable<TEntity>> SearchAsync(string searchText, string orderBy, CancellationToken cancellationToken = default);
+    Task<PagedResult<TEntity>> PagedSearchAsync(string searchText, string orderBy, int page, int pageSize, CancellationToken cancellationToken = default);
     Task<IEnumerable<TEntity>> GetListAsync(CancellationToken cancellationToken = default);
     Task<TEntity?> GetAsync(string id, CancellationToken cancellationToken = default);
     Task CreateAsync(TEntity newEntity, CancellationToken cancellationToken = default);

--- a/MediaSet.Api/Shared/Models/PagedResult.cs
+++ b/MediaSet.Api/Shared/Models/PagedResult.cs
@@ -1,0 +1,10 @@
+namespace MediaSet.Api.Shared.Models;
+
+public record PagedResult<T>(
+    IEnumerable<T> Items,
+    long TotalCount,
+    int Page,
+    int PageSize)
+{
+    public int TotalPages => (int)Math.Ceiling((double)TotalCount / PageSize);
+}

--- a/MediaSet.Remix/app/api/entity-data.ts
+++ b/MediaSet.Remix/app/api/entity-data.ts
@@ -4,6 +4,14 @@ import { BaseEntity, Entity } from '~/models';
 import { serverLogger } from '~/utils/serverLogger';
 import { apiFetch } from '~/utils/apiFetch.server';
 
+export type PagedResult<TEntity> = {
+  items: TEntity[];
+  totalCount: number;
+  page: number;
+  pageSize: number;
+  totalPages: number;
+};
+
 function getEntityType<T extends BaseEntity>(entity: T): Entity {
   return entity.type;
 }
@@ -40,6 +48,54 @@ export async function searchEntities<TEntity extends BaseEntity>(
     return entities;
   } catch (error) {
     serverLogger.error('Error searching entities', { operation: 'searchEntities', entityType, error: String(error) });
+    throw error;
+  }
+}
+
+export async function pagedSearchEntities<TEntity extends BaseEntity>(
+  entityType: Entity,
+  searchText: string | null,
+  orderBy: string = '',
+  page: number = 1,
+  pageSize: number = 75
+): Promise<PagedResult<TEntity>> {
+  serverLogger.info(
+    `Paged searching for ${entityType} with searchText: ${searchText}, orderBy: ${orderBy}, page: ${page}`,
+    {
+      operation: 'pagedSearchEntities',
+      entityType,
+      searchText,
+      orderBy,
+      page,
+      pageSize,
+    }
+  );
+  try {
+    const response = await apiFetch(
+      `${baseUrl}/${entityType}/pagedsearch?searchText=${searchText ?? ''}&orderBy=${orderBy}&page=${page}&pageSize=${pageSize}`
+    );
+    if (!response.ok) {
+      serverLogger.error(`Failed to fetch ${entityType} paged search results`, {
+        operation: 'pagedSearchEntities',
+        entityType,
+        status: response.status,
+      });
+      throw new Response('Error fetching data', { status: 500 });
+    }
+    const result = (await response.json()) as PagedResult<TEntity>;
+    serverLogger.info(`Successfully fetched ${result.items.length}/${result.totalCount} ${entityType}`, {
+      operation: 'pagedSearchEntities',
+      entityType,
+      count: result.items.length,
+      totalCount: result.totalCount,
+    });
+    return result;
+  } catch (error) {
+    serverLogger.error('Error paged searching entities', {
+      operation: 'pagedSearchEntities',
+      entityType,
+      error: String(error),
+    });
     throw error;
   }
 }

--- a/MediaSet.Remix/app/components/inputs/pagination.tsx
+++ b/MediaSet.Remix/app/components/inputs/pagination.tsx
@@ -1,0 +1,61 @@
+import { Link, useNavigate } from '@remix-run/react';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+
+type PaginationProps = {
+  page: number;
+  totalPages: number;
+  totalCount: number;
+  searchText?: string | null;
+  orderBy?: string;
+  basePath: string;
+};
+
+export default function Pagination({ page, totalPages, totalCount, searchText, orderBy, basePath }: PaginationProps) {
+  const navigate = useNavigate();
+
+  if (totalPages <= 1) return null;
+
+  const buildUrl = (targetPage: number) => {
+    const params = new URLSearchParams();
+    if (searchText) params.set('searchText', searchText);
+    if (orderBy) params.set('orderBy', orderBy);
+    params.set('page', String(targetPage));
+    return `${basePath}?${params.toString()}`;
+  };
+
+  return (
+    <div className="sticky bottom-2 mb-2 flex items-center justify-center gap-6 py-3 px-4 bg-entity/20 border border-entity/30 rounded-lg backdrop-blur-sm">
+      <span className="text-sm text-gray-400">{totalCount} items</span>
+      {page > 1 ? (
+        <Link to={buildUrl(page - 1)} className="flex items-center gap-1">
+          <ChevronLeft size={16} /> Prev
+        </Link>
+      ) : (
+        <span className="flex items-center gap-1 text-gray-600 cursor-not-allowed select-none">
+          <ChevronLeft size={16} /> Prev
+        </span>
+      )}
+      <select
+        value={page}
+        onChange={(e) => navigate(buildUrl(Number(e.target.value)))}
+        className="bg-gray-800 border border-gray-600 text-white dark:text-white rounded px-2 py-1 text-sm"
+        aria-label="Select page"
+      >
+        {Array.from({ length: totalPages }, (_, i) => i + 1).map((p) => (
+          <option key={p} value={p}>
+            Page {p} of {totalPages}
+          </option>
+        ))}
+      </select>
+      {page < totalPages ? (
+        <Link to={buildUrl(page + 1)} className="flex items-center gap-1">
+          Next <ChevronRight size={16} />
+        </Link>
+      ) : (
+        <span className="flex items-center gap-1 text-gray-600 cursor-not-allowed select-none">
+          Next <ChevronRight size={16} />
+        </span>
+      )}
+    </div>
+  );
+}

--- a/MediaSet.Remix/app/routes/$entity._index/route.test.tsx
+++ b/MediaSet.Remix/app/routes/$entity._index/route.test.tsx
@@ -8,8 +8,12 @@ import { Entity, BookEntity, MovieEntity, GameEntity, MusicEntity } from '~/mode
 vi.mock('~/api/entity-data');
 vi.mock('~/utils/helpers');
 
-const mockSearchEntities = vi.mocked(entityData.searchEntities);
+const mockPagedSearchEntities = vi.mocked(entityData.pagedSearchEntities);
 const mockGetEntityFromParams = vi.mocked(helpers.getEntityFromParams);
+
+function makePagedResult<T>(items: T[]) {
+  return { items, totalCount: items.length, page: 1, pageSize: 25, totalPages: 1 };
+}
 
 describe('$entity._index route', () => {
   describe('meta function', () => {
@@ -61,7 +65,7 @@ describe('$entity._index route', () => {
       ];
 
       mockGetEntityFromParams.mockReturnValue(Entity.Books);
-      mockSearchEntities.mockResolvedValue(mockBooks);
+      mockPagedSearchEntities.mockResolvedValue(makePagedResult(mockBooks));
 
       const mockRequest = new Request('http://localhost/books?searchText=test');
       const result = await loader({
@@ -69,9 +73,10 @@ describe('$entity._index route', () => {
         params: { entity: 'books' },
       } as unknown as Parameters<typeof loader>[0]);
 
-      expect(mockSearchEntities).toHaveBeenCalledWith(Entity.Books, 'test', 'title:asc');
+      expect(mockPagedSearchEntities).toHaveBeenCalledWith(Entity.Books, 'test', 'title:asc', 1);
       expect(result).toEqual({
         entities: mockBooks,
+        pagination: { page: 1, totalPages: 1, totalCount: mockBooks.length },
         entityType: Entity.Books,
         searchText: 'test',
         orderBy: 'title:asc',
@@ -89,7 +94,7 @@ describe('$entity._index route', () => {
       ];
 
       mockGetEntityFromParams.mockReturnValue(Entity.Movies);
-      mockSearchEntities.mockResolvedValue(mockMovies);
+      mockPagedSearchEntities.mockResolvedValue(makePagedResult(mockMovies));
 
       const mockRequest = new Request('http://localhost/movies');
       const result = await loader({
@@ -97,9 +102,10 @@ describe('$entity._index route', () => {
         params: { entity: 'movies' },
       } as unknown as Parameters<typeof loader>[0]);
 
-      expect(mockSearchEntities).toHaveBeenCalledWith(Entity.Movies, null, 'title:asc');
+      expect(mockPagedSearchEntities).toHaveBeenCalledWith(Entity.Movies, null, 'title:asc', 1);
       expect(result).toEqual({
         entities: mockMovies,
+        pagination: { page: 1, totalPages: 1, totalCount: mockMovies.length },
         entityType: Entity.Movies,
         searchText: null,
         orderBy: 'title:asc',
@@ -118,7 +124,7 @@ describe('$entity._index route', () => {
       ];
 
       mockGetEntityFromParams.mockReturnValue(Entity.Games);
-      mockSearchEntities.mockResolvedValue(mockGames);
+      mockPagedSearchEntities.mockResolvedValue(makePagedResult(mockGames));
 
       const mockRequest = new Request('http://localhost/games?searchText=action');
       const result = await loader({
@@ -126,9 +132,10 @@ describe('$entity._index route', () => {
         params: { entity: 'games' },
       } as unknown as Parameters<typeof loader>[0]);
 
-      expect(mockSearchEntities).toHaveBeenCalledWith(Entity.Games, 'action', 'title:asc');
+      expect(mockPagedSearchEntities).toHaveBeenCalledWith(Entity.Games, 'action', 'title:asc', 1);
       expect(result).toEqual({
         entities: mockGames,
+        pagination: { page: 1, totalPages: 1, totalCount: mockGames.length },
         entityType: Entity.Games,
         searchText: 'action',
         orderBy: 'title:asc',
@@ -147,7 +154,7 @@ describe('$entity._index route', () => {
       ];
 
       mockGetEntityFromParams.mockReturnValue(Entity.Musics);
-      mockSearchEntities.mockResolvedValue(mockMusics);
+      mockPagedSearchEntities.mockResolvedValue(makePagedResult(mockMusics));
 
       const mockRequest = new Request('http://localhost/musics?searchText=rock');
       const result = await loader({
@@ -155,9 +162,10 @@ describe('$entity._index route', () => {
         params: { entity: 'musics' },
       } as unknown as Parameters<typeof loader>[0]);
 
-      expect(mockSearchEntities).toHaveBeenCalledWith(Entity.Musics, 'rock', 'title:asc');
+      expect(mockPagedSearchEntities).toHaveBeenCalledWith(Entity.Musics, 'rock', 'title:asc', 1);
       expect(result).toEqual({
         entities: mockMusics,
+        pagination: { page: 1, totalPages: 1, totalCount: mockMusics.length },
         entityType: Entity.Musics,
         searchText: 'rock',
         orderBy: 'title:asc',
@@ -167,7 +175,7 @@ describe('$entity._index route', () => {
 
     it('should handle empty search results', async () => {
       mockGetEntityFromParams.mockReturnValue(Entity.Books);
-      mockSearchEntities.mockResolvedValue([]);
+      mockPagedSearchEntities.mockResolvedValue(makePagedResult([]));
 
       const mockRequest = new Request('http://localhost/books?searchText=nonexistent');
       const result = await loader({
@@ -177,6 +185,7 @@ describe('$entity._index route', () => {
 
       expect(result).toEqual({
         entities: [],
+        pagination: { page: 1, totalPages: 1, totalCount: 0 },
         entityType: Entity.Books,
         searchText: 'nonexistent',
         orderBy: 'title:asc',
@@ -203,7 +212,7 @@ describe('$entity._index route', () => {
       ];
 
       mockGetEntityFromParams.mockReturnValue(Entity.Books);
-      mockSearchEntities.mockResolvedValue(mockBooks);
+      mockPagedSearchEntities.mockResolvedValue(makePagedResult(mockBooks));
 
       const mockRequest = new Request('http://localhost/books?searchText=book');
       const result = await loader({
@@ -217,7 +226,7 @@ describe('$entity._index route', () => {
 
     it('should pass correct entity type to searchEntities', async () => {
       mockGetEntityFromParams.mockReturnValue(Entity.Games);
-      mockSearchEntities.mockResolvedValue([]);
+      mockPagedSearchEntities.mockResolvedValue(makePagedResult([]));
 
       const mockRequest = new Request('http://localhost/games?searchText=zelda');
       await loader({
@@ -226,12 +235,12 @@ describe('$entity._index route', () => {
       } as unknown as Parameters<typeof loader>[0]);
 
       expect(mockGetEntityFromParams).toHaveBeenCalledWith({ entity: 'games' });
-      expect(mockSearchEntities).toHaveBeenCalledWith(Entity.Games, 'zelda', 'title:asc');
+      expect(mockPagedSearchEntities).toHaveBeenCalledWith(Entity.Games, 'zelda', 'title:asc', 1);
     });
 
     it('should extract search text from URL query parameters', async () => {
       mockGetEntityFromParams.mockReturnValue(Entity.Books);
-      mockSearchEntities.mockResolvedValue([]);
+      mockPagedSearchEntities.mockResolvedValue(makePagedResult([]));
 
       const mockRequest = new Request('http://localhost/books?searchText=multiple%20words');
       await loader({
@@ -239,12 +248,12 @@ describe('$entity._index route', () => {
         params: { entity: 'books' },
       } as unknown as Parameters<typeof loader>[0]);
 
-      expect(mockSearchEntities).toHaveBeenCalledWith(Entity.Books, 'multiple words', 'title:asc');
+      expect(mockPagedSearchEntities).toHaveBeenCalledWith(Entity.Books, 'multiple words', 'title:asc', 1);
     });
 
     it('should handle null search text when not provided', async () => {
       mockGetEntityFromParams.mockReturnValue(Entity.Movies);
-      mockSearchEntities.mockResolvedValue([]);
+      mockPagedSearchEntities.mockResolvedValue(makePagedResult([]));
 
       const mockRequest = new Request('http://localhost/movies');
       await loader({
@@ -252,12 +261,12 @@ describe('$entity._index route', () => {
         params: { entity: 'movies' },
       } as unknown as Parameters<typeof loader>[0]);
 
-      expect(mockSearchEntities).toHaveBeenCalledWith(Entity.Movies, null, 'title:asc');
+      expect(mockPagedSearchEntities).toHaveBeenCalledWith(Entity.Movies, null, 'title:asc', 1);
     });
 
     it('should pass orderBy from URL to searchEntities', async () => {
       mockGetEntityFromParams.mockReturnValue(Entity.Books);
-      mockSearchEntities.mockResolvedValue([]);
+      mockPagedSearchEntities.mockResolvedValue(makePagedResult([]));
 
       const mockRequest = new Request('http://localhost/books?orderBy=format:desc');
       const result = await loader({
@@ -265,13 +274,13 @@ describe('$entity._index route', () => {
         params: { entity: 'books' },
       } as unknown as Parameters<typeof loader>[0]);
 
-      expect(mockSearchEntities).toHaveBeenCalledWith(Entity.Books, null, 'format:desc');
+      expect(mockPagedSearchEntities).toHaveBeenCalledWith(Entity.Books, null, 'format:desc', 1);
       expect(result).toMatchObject({ orderBy: 'format:desc' });
     });
 
     it('should default orderBy to title:asc when not provided', async () => {
       mockGetEntityFromParams.mockReturnValue(Entity.Books);
-      mockSearchEntities.mockResolvedValue([]);
+      mockPagedSearchEntities.mockResolvedValue(makePagedResult([]));
 
       const mockRequest = new Request('http://localhost/books?searchText=test');
       const result = await loader({
@@ -279,7 +288,7 @@ describe('$entity._index route', () => {
         params: { entity: 'books' },
       } as unknown as Parameters<typeof loader>[0]);
 
-      expect(mockSearchEntities).toHaveBeenCalledWith(Entity.Books, 'test', 'title:asc');
+      expect(mockPagedSearchEntities).toHaveBeenCalledWith(Entity.Books, 'test', 'title:asc', 1);
       expect(result).toMatchObject({ orderBy: 'title:asc' });
     });
   });

--- a/MediaSet.Remix/app/routes/$entity._index/route.tsx
+++ b/MediaSet.Remix/app/routes/$entity._index/route.tsx
@@ -2,7 +2,7 @@ import type { LoaderFunctionArgs, MetaFunction } from '@remix-run/node';
 import { Form, Link, useLoaderData, useNavigate } from '@remix-run/react';
 import { useEffect } from 'react';
 import { Plus, X } from 'lucide-react';
-import { searchEntities } from '~/api/entity-data';
+import { pagedSearchEntities } from '~/api/entity-data';
 import { BookEntity, Entity, GameEntity, MovieEntity, MusicEntity } from '~/models';
 import { getEntityFromParams } from '~/utils/helpers';
 import { clientApiUrl } from '~/constants.server';
@@ -10,6 +10,7 @@ import Books from './components/books';
 import Movies from './components/movies';
 import Games from './components/games';
 import Musics from './components/musics';
+import Pagination from '~/components/inputs/pagination';
 import invariant from 'tiny-invariant';
 
 export const meta: MetaFunction = (loader) => {
@@ -22,15 +23,23 @@ export const loader = async ({ request, params }: LoaderFunctionArgs) => {
   const url = new URL(request.url);
   const searchText = url.searchParams.get('searchText');
   const orderBy = url.searchParams.get('orderBy') ?? 'title:asc';
+  const page = parseInt(url.searchParams.get('page') ?? '1', 10);
   const entityType: Entity = getEntityFromParams(params);
 
-  const entities = await searchEntities(entityType, searchText, orderBy);
+  const pagedResult = await pagedSearchEntities(entityType, searchText, orderBy, page);
   const apiUrl = clientApiUrl;
-  return { entities, entityType, searchText, orderBy, apiUrl };
+  return {
+    entities: pagedResult.items,
+    pagination: { page: pagedResult.page, totalPages: pagedResult.totalPages, totalCount: pagedResult.totalCount },
+    entityType,
+    searchText,
+    orderBy,
+    apiUrl,
+  };
 };
 
 export default function Index() {
-  const { entities, entityType, searchText, orderBy, apiUrl } = useLoaderData<typeof loader>();
+  const { entities, pagination, entityType, searchText, orderBy, apiUrl } = useLoaderData<typeof loader>();
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -108,6 +117,14 @@ export default function Index() {
           </>
         )}
       </div>
+      <Pagination
+        page={pagination.page}
+        totalPages={pagination.totalPages}
+        totalCount={pagination.totalCount}
+        searchText={searchText}
+        orderBy={orderBy}
+        basePath={`/${entityType.toLowerCase()}`}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Adds a new `GET /pagedsearch` endpoint on all entity routes returning a `PagedResult<T>` with items, total count, page, page size, and total pages (default page size: 75)
- Switches the entity list view loader from `searchEntities` to `pagedSearchEntities`, reading `page` from URL params
- Adds a sticky, entity-colored `Pagination` component at the bottom of the list view with Prev/Next links and a page-select dropdown for direct page navigation

## Test plan
- [x] Navigate to any entity list (Books, Movies, Games, Music) and verify items are paginated
- [x] Verify Prev/Next links and the page-select dropdown navigate correctly, preserving `searchText` and `orderBy` in the URL
- [x] Verify sorting resets to page 1
- [x] Verify searching resets to page 1
- [x] Verify the pagination bar matches the main content width, uses the entity accent color, and does not overlap the footer when scrolled to the bottom
- [x] Verify the pagination bar does not appear when all results fit on one page

Closes #524

🤖 Generated with [Claude Code](https://claude.com/claude-code)