### PR TITLE
fix(security): encode query params in search endpoints closes #572

### DIFF
--- a/MediaSet.Remix/app/api/entity-data.ts
+++ b/MediaSet.Remix/app/api/entity-data.ts
@@ -28,9 +28,10 @@ export async function searchEntities<TEntity extends BaseEntity>(
     orderBy,
   });
   try {
-    const response = await apiFetch(
-      `${baseUrl}/${entityType}/search?searchText=${searchText ?? ''}&orderBy=${orderBy}`
-    );
+    const searchParams = new URLSearchParams();
+    searchParams.set('searchText', searchText ?? '');
+    searchParams.set('orderBy', orderBy);
+    const response = await apiFetch(`${baseUrl}/${entityType}/search?${searchParams.toString()}`);
     if (!response.ok) {
       serverLogger.error(`Failed to fetch ${entityType} search results`, {
         operation: 'searchEntities',
@@ -71,9 +72,12 @@ export async function pagedSearchEntities<TEntity extends BaseEntity>(
     }
   );
   try {
-    const response = await apiFetch(
-      `${baseUrl}/${entityType}/pagedsearch?searchText=${searchText ?? ''}&orderBy=${orderBy}&page=${page}&pageSize=${pageSize}`
-    );
+    const searchParams = new URLSearchParams();
+    searchParams.set('searchText', searchText ?? '');
+    searchParams.set('orderBy', orderBy);
+    searchParams.set('page', String(page));
+    searchParams.set('pageSize', String(pageSize));
+    const response = await apiFetch(`${baseUrl}/${entityType}/pagedsearch?${searchParams.toString()}`);
     if (!response.ok) {
       serverLogger.error(`Failed to fetch ${entityType} paged search results`, {
         operation: 'pagedSearchEntities',


### PR DESCRIPTION
## Summary

- Use `URLSearchParams` to encode `searchText` and `orderBy` in the `/search` endpoint call
- Use `URLSearchParams` to encode `searchText`, `orderBy`, `page`, and `pageSize` in the `/pagedsearch` endpoint call
- Prevents query parameter injection where a crafted `searchText` value (e.g. `foo&admin=true`) could inject arbitrary parameters

## Test plan

- [x] Verify search works normally with plain text input
- [x] Verify special characters in search input (e.g. `&`, `=`, `+`) are properly encoded and do not inject extra query params

closes #572

🤖 Generated with [Claude Code](https://claude.com/claude-code)