### PR TITLE
fix(security): production application hardening

### DIFF
--- a/MediaSet.Api/Features/Entities/Endpoints/EntityApi.cs
+++ b/MediaSet.Api/Features/Entities/Endpoints/EntityApi.cs
@@ -225,7 +225,7 @@ internal static class EntityApi
             catch (Exception ex)
             {
                 logger.LogError(ex, "Error creating {entityType}", entityType);
-                return TypedResults.BadRequest($"Error creating entity: {ex.Message}");
+                return TypedResults.BadRequest("An error occurred while creating the entity.");
             }
         }).DisableAntiforgery();
 
@@ -405,7 +405,7 @@ internal static class EntityApi
             catch (Exception ex)
             {
                 logger.LogError(ex, "Error updating {entityType}/{id}", entityType, id);
-                return TypedResults.BadRequest($"Error updating entity: {ex.Message}");
+                return TypedResults.BadRequest("An error occurred while updating the entity.");
             }
         }).DisableAntiforgery();
 

--- a/MediaSet.Api/Program.cs
+++ b/MediaSet.Api/Program.cs
@@ -278,6 +278,8 @@ else
 // Configure SerilogTracing to capture spans and write to Seq
 using var listener = LoggingExtensions.ConfigureSerilogTracing();
 
+var enableSwagger = builder.Configuration.GetValue<bool>("EnableSwagger");
+
 var app = builder.Build();
 
 app.UseHttpsRedirection();
@@ -288,13 +290,12 @@ app.UseMiddleware<TraceIdHeaderMiddleware>();
 app.UseHttpLoggingFilterMiddleware();
 app.UseHttpLoggingMiddleware();
 
-// turn on swagger for all environments for now
 // Configure the HTTP request pipeline.
-// if (app.Environment.IsDevelopment())
-// {
-app.UseSwagger();
-app.UseSwaggerUI();
-// }
+if (app.Environment.IsDevelopment() || enableSwagger)
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
 
 // Configure static file serving for images folder
 if (imageConfig != null)

--- a/MediaSet.Api/appsettings.Development.json
+++ b/MediaSet.Api/appsettings.Development.json
@@ -1,4 +1,5 @@
 {
+  "AllowedHosts": "*",
   "MediaSetDatabaseSettings": {
     "ConnectionString": "mongodb://mongodb:27017",
     "DatabaseName": "MediaSet"

--- a/MediaSet.Api/appsettings.json
+++ b/MediaSet.Api/appsettings.json
@@ -6,6 +6,7 @@
     }
   },
   "AllowedHosts": "*",
+  "EnableSwagger": false,
   "ExternalLogging": {
     "Enabled": false
   },

--- a/MediaSet.Remix/app/routes/image-stats.tsx
+++ b/MediaSet.Remix/app/routes/image-stats.tsx
@@ -1,5 +1,5 @@
 import { type ActionFunctionArgs, type MetaFunction } from '@remix-run/node';
-import { useLoaderData, Link, Form, useNavigation } from '@remix-run/react';
+import { useLoaderData, useActionData, Link, Form, useNavigation } from '@remix-run/react';
 import Tabs, { type TabConfig } from '~/components/common/tabs';
 import {
   getImageStats,
@@ -43,7 +43,16 @@ export const action = async ({ request }: ActionFunctionArgs) => {
   } else if (intent === 'reset-lookup') {
     const entityType = formData.get('entityType') as string;
     const entityIdsRaw = formData.get('entityIds') as string;
-    const entityIds = JSON.parse(entityIdsRaw) as string[];
+    let entityIds: string[];
+    try {
+      const parsed = JSON.parse(entityIdsRaw);
+      if (!Array.isArray(parsed) || !parsed.every((id) => typeof id === 'string')) {
+        throw new Error('Invalid format');
+      }
+      entityIds = parsed;
+    } catch {
+      return { error: 'Invalid entity IDs format.' };
+    }
     await resetImageLookup(entityIds, entityType);
   }
   return null;
@@ -113,6 +122,7 @@ function groupOrphanedByEntityType(files: OrphanedImageFile[]): Record<string, O
 
 export default function ImageStatsPage() {
   const { stats } = useLoaderData<typeof loader>();
+  const actionData = useActionData<typeof action>();
   const navigation = useNavigation();
   const isDeleting = navigation.state === 'submitting' && navigation.formData?.get('intent') === 'delete-orphaned';
   const isResettingLookup = navigation.state === 'submitting' && navigation.formData?.get('intent') === 'reset-lookup';
@@ -343,6 +353,12 @@ export default function ImageStatsPage() {
       <p className="text-sm text-zinc-400" suppressHydrationWarning>
         Last updated: {new Date(stats.lastUpdated).toLocaleString()}
       </p>
+
+      {actionData?.error && (
+        <div className="rounded-lg border border-red-500/20 bg-red-500/10 p-4 text-sm text-red-400">
+          {actionData.error}
+        </div>
+      )}
 
       {/* Overview */}
       <div>

--- a/Setup/CONTAINER_SETUP.md
+++ b/Setup/CONTAINER_SETUP.md
@@ -3,16 +3,33 @@
 This guide explains how to run the MediaSet application using Docker Compose and the provided `docker-compose.prod.yml`. It is written for someone who wants to run the application locally (tester / end-user), not for development work.
 
 Prerequisites
+
 - Docker Engine (20.10+) or Podman with Docker-compatibility
 - Docker Compose v2 (the `docker compose` CLI) or `podman compose`
 - Sufficient disk space for images and MongoDB data
 
 Overview
+
 - The production compose file `docker-compose.prod.yml` defines three services: `mediaset-api`, `mediaset-ui`, and `mongo`.
 
 Configuration approach
 
 - Edit `docker-compose.prod.yml` directly: open the file and update the `environment:` entries under each service (for example `mediaset-api` and `mediaset-ui`). This is the recommended approach for end users — the compose file is self-contained and explicit.
+
+AllowedHosts
+
+The `AllowedHosts` setting controls which `Host` header values the API will accept. It defaults to `localhost`. In production you should set it to the hostname(s) or IP address(es) your instance is reachable at to prevent host header injection attacks.
+
+- Multiple values are semicolon-separated: `localhost;mediaset.domain.com`
+- IP addresses are supported: `192.168.50.10;localhost`
+- Use a leading dot as a subdomain wildcard: `.domain.com` matches `mediaset.domain.com`, `www.domain.com`, etc.
+- If the API is accessed on a non-standard port, include the port in the value: `192.168.50.10:8080`
+
+Set it in `docker-compose.prod.yml` under the `mediaset-api` environment block — replace the `[ReplaceThis]` placeholder with your hostname(s):
+
+```yaml
+AllowedHosts: "mediaset.domain.com"
+```
 
 Integration placeholders and enabling
 
@@ -24,11 +41,12 @@ By default integration settings (OpenLibrary, TMDB, IGDB, etc.) are commented ou
 
 Placeholders you must replace (examples)
 
+- `AllowedHosts` — replace `[ReplaceThis]` with the hostname(s) your API is reachable at (e.g., `mediaset.domain.com`). See the AllowedHosts section above for syntax details.
+- `clientApiUrl` — replace `[ReplaceThis]` with the API URL browsers should use (e.g., `http://localhost:8080`).
 - `OpenLibraryConfiguration__ContactEmail` — replace `[ReplaceThis]` with your contact email for OpenLibrary.
 - `TmdbConfiguration__BearerToken` — replace `[ReplaceThis]` with your TMDB bearer token.
 - `IgdbConfiguration__ClientId` — replace `[ReplaceThis]` with your Twitch Client ID.
 - `IgdbConfiguration__ClientSecret` — replace `[ReplaceThis]` with your Twitch Client Secret.
-- `clientApiUrl` — replace `[ReplaceThis]` with the API URL browsers should use (e.g., `http://localhost:8080`).
 
 Starting the application
 
@@ -54,6 +72,7 @@ docker ps --filter "name=mediaset"
 ```
 
 Access the application
+
 - Frontend (UI): http://localhost:3000
 - API: http://localhost:8080
 
@@ -138,4 +157,3 @@ Where to get help
 - Check container logs (`docker compose -f docker-compose.prod.yml logs`) for errors.
 - Inspect service-specific logs with `docker logs <container-name>` (container names appear in `docker ps`).
 - Open an issue in the repository if a reproducible problem remains.
-

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -7,6 +7,7 @@
 #
 # Required environment variables:
 #   - MONGODB_CONNECTION_STRING: MongoDB connection string (default: mongodb://mongo:27017)
+#   - AllowedHosts: Semicolon-separated list of hostnames/IPs the API is reachable at (e.g., sub.domain.com)
 #
 # Optional environment variables (for barcode/metadata lookup features):
 #   - OPENLIBRARY_CONTACT_EMAIL: Your email for OpenLibrary API (required for book lookup)
@@ -16,7 +17,7 @@
 #   - MUSICBRAINZ_USER_AGENT: MusicBrainz user agent (optional, e.g., "MyApp/1.0 (contact@example.com)")
 #   - UPCITEMDB_API_KEY: UpcItemDb API key (optional, but improves lookup accuracy)
 
-version: '3.8'
+version: "3.8"
 
 services:
   mediaset-api:
@@ -30,6 +31,13 @@ services:
       ASPNETCORE_URLS: "http://+:8080"
       ASPNETCORE_ENVIRONMENT: "Production"
 
+      # Restrict accepted Host headers to prevent host header injection attacks.
+      # Set this to the hostname(s) or IP(s) your instance is reachable at.
+      # Semicolon-separated. Use a leading dot for subdomain wildcards: .domain.com
+      # If accessed on a non-standard port, include it: 192.168.1.10:8080
+      # See Setup/CONTAINER_SETUP.md for full details.
+      AllowedHosts: "[ReplaceThis]"
+
       # Timezone configuration (defaults to UTC if not set)
       # Set this to your local timezone for accurate scheduling and logs
       # Examples: America/New_York, Europe/London, Asia/Tokyo
@@ -39,29 +47,29 @@ services:
       # Database configuration
       MediaSetDatabaseSettings__ConnectionString: "${MONGODB_CONNECTION_STRING:-mongodb://mongo:27017}"
       MediaSetDatabaseSettings__DatabaseName: "MediaSet"
-      
+
       # Cache settings
       CacheSettings__EnableCaching: "true"
       CacheSettings__DefaultCacheDurationMinutes: "10"
       CacheSettings__MetadataCacheDurationMinutes: "10"
       CacheSettings__StatsCacheDurationMinutes: "10"
-      
+
       # Image storage configuration
       ImageConfiguration__StoragePath: "/app/data/images"
       ImageConfiguration__MaxFileSizeMb: "5"
       ImageConfiguration__AllowedImageExtensions: "jpg,jpeg,png"
       ImageConfiguration__HttpTimeoutSeconds: "30"
-      
+
       # OpenLibrary configuration (for book lookup)
       # OpenLibraryConfiguration__BaseUrl: "https://openlibrary.org/"
       # OpenLibraryConfiguration__Timeout: "30"
       # OpenLibraryConfiguration__ContactEmail: "[ReplaceThis]"
-      
+
       # TMDB configuration (for movie lookup)
       # TmdbConfiguration__BaseUrl: "https://api.themoviedb.org/3/"
       # TmdbConfiguration__BearerToken: "[ReplaceThis]"
       # TmdbConfiguration__Timeout: "10"
-      
+
       # UpcItemDb configuration (for barcode lookup)
       # Free tier: 100 requests/day, 6 requests/minute burst
       # UpcItemDbConfiguration__BaseUrl: "https://api.upcitemdb.com/"
@@ -70,21 +78,21 @@ services:
       # UpcItemDbConfiguration__MaxRequestsPerDay: "90"
       # UpcItemDbConfiguration__MinDelayBetweenRequestsMs: "1000"
       # UpcItemDbConfiguration__MaxRetryPauseSeconds: "65"
-      
+
       # IGDB configuration (for game lookup)
       # IgdbConfiguration__ClientId: "[ReplaceThis]"        # Twitch Client ID
       # IgdbConfiguration__ClientSecret: "[ReplaceThis]"    # Twitch Client Secret
-      
+
       # MusicBrainz configuration (for music lookup)
       # MusicBrainzConfiguration__BaseUrl: "https://musicbrainz.org/"
       # MusicBrainzConfiguration__Timeout: "10"
       # MusicBrainzConfiguration__UserAgent: "${MUSICBRAINZ_USER_AGENT:-MediaSet/1.0 (https://github.com/paulmfischer/MediaSet)}"
-      
+
       # Seq logging configuration (for centralized structured logging)
       # See Setup/SEQ_SETUP.md for detailed configuration guide
       # ExternalLogging__Enabled: "true"
       # ExternalLogging__SeqUrl: "[ReplaceThis]"
-      
+
       # HTTP logging exclusions (reduces noise in logs by excluding specific paths)
       # HttpLoggingFilterOptions__ExcludedPaths__0: "/api/logs"
       # HttpLoggingFilterOptions__ExcludedPaths__1: "/health"
@@ -105,20 +113,20 @@ services:
     volumes:
       # Persist uploaded images
       - mediaset-images:/app/data/images
-    
+
     depends_on:
       - mongo
-    
+
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
       interval: 30s
       timeout: 10s
       retries: 3
       start_period: 40s
-    
+
     networks:
       - mediaset
-  
+
   mediaset-ui:
     image: ghcr.io/paulmfischer/mediaset-ui:latest
     container_name: mediaset-ui
@@ -128,23 +136,23 @@ services:
     environment:
       # Server-side API URL - for Remix server to call API (uses Docker container name)
       apiUrl: "${API_URL:-http://mediaset-api:8080}"
-      
+
       # Client-side API URL - for browser to access API (must be externally accessible)
       # In production, this should be the public URL of your API
       clientApiUrl: "[ReplaceThis]"
-      
+
       # Node environment
       NODE_ENV: "production"
-      
+
       # Optional: Enable detailed error messages (not recommended for production)
       # SHOW_ERROR_DETAILS: "false"
-    
+
     depends_on:
       - mediaset-api
-    
+
     networks:
       - mediaset
-  
+
   mongo:
     image: mongo:7.0
     container_name: mediaset-mongo

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -45,7 +45,10 @@ services:
       # TZ: "America/New_York"
 
       # Database configuration
+      # Without authentication (default):
       MediaSetDatabaseSettings__ConnectionString: "${MONGODB_CONNECTION_STRING:-mongodb://mongo:27017}"
+      # With authentication (if MongoDB auth is enabled on the mongo service below):
+      # MediaSetDatabaseSettings__ConnectionString: "mongodb://username:password@mongo:27017/?authSource=admin"
       MediaSetDatabaseSettings__DatabaseName: "MediaSet"
 
       # Cache settings
@@ -159,6 +162,10 @@ services:
     restart: unless-stopped
     environment:
       MONGO_INITDB_DATABASE: "MediaSet"
+      # Optional: enable MongoDB authentication (recommended for production)
+      # If enabled, update the API connection string above to include credentials
+      # MONGO_INITDB_ROOT_USERNAME: "[ReplaceThis]"
+      # MONGO_INITDB_ROOT_PASSWORD: "[ReplaceThis]"
     volumes:
       - mediaset-db:/data/db
     networks:


### PR DESCRIPTION
## Summary

Addresses all security issues identified in #574.

- **Swagger UI** — gated on `IsDevelopment() || EnableSwagger` config flag; defaults to `false` in `appsettings.json` so production deployments are unexposed unless explicitly opted in
- **AllowedHosts** — defaults to `*` for out-of-the-box compatibility; prod compose now has a required `[ReplaceThis]` placeholder with documentation in `Setup/CONTAINER_SETUP.md` explaining hostname, IP, port, and subdomain wildcard syntax
- **HSTS** — addressed at the reverse proxy level (Nginx Proxy Manager SSL tab); no app-level change needed since TLS is terminated by the proxy
- **MongoDB auth** — prod compose updated with optional commented-out `MONGO_INITDB_ROOT_USERNAME/PASSWORD` placeholders and an authenticated connection string example
- **Exception message leakage** — `BadRequest` responses in `EntityApi.cs` now return generic messages; full exception details remain in server logs only
- **Unsafe JSON.parse** — wrapped in try/catch with array/string shape validation; invalid input returns a user-visible inline error on the image stats page

## Test plan

- [x] Swagger is not accessible in production (`ASPNETCORE_ENVIRONMENT=Production`) without `EnableSwagger=true`
- [x] Swagger is accessible in development or when `EnableSwagger=true` is set
- [x] App starts and serves requests normally in development (AllowedHosts `*`)
- [x] Creating/updating an entity with a simulated error returns a generic message, not exception details
- [x] Image stats reset lookup action handles malformed `entityIds` gracefully and displays the error inline

closes #574

🤖 Generated with [Claude Code](https://claude.com/claude-code)