### PR TITLE
fix(security): logging and information disclosure hardening

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,8 +8,8 @@ clientApiUrl=http://localhost:5000
 NODE_ENV=development
 REMIX_DEV_HTTP_ORIGIN=http://localhost:3000
 
-# Optional: Show detailed error information in the browser (development only)
-SHOW_ERROR_DETAILS=false
+# Show detailed error information in the browser (dev only, never enable in production)
+# VITE_SHOW_ERROR_DETAILS=true
 
 # API (.NET) Configuration  
 ASPNETCORE_ENVIRONMENT=Development
@@ -39,3 +39,7 @@ ASPNETCORE_URLS=http://+:5000;https://+:5001
 
 # MongoDB Configuration
 MONGO_INITDB_DATABASE=MediaSet
+
+# External Logging (Seq) - optional, disabled by default
+# ExternalLogging__Enabled=true
+# ExternalLogging__SeqUrl=http://your-seq-host:5341

--- a/.github/instructions/shared.md
+++ b/.github/instructions/shared.md
@@ -65,6 +65,29 @@ When working on tasks that require code changes:
    - Include relevant description summarizing changes and motivation
    - Reference related issues with `closes #N` or `refs #N`
 
+## Local Configuration (User Secrets)
+
+Sensitive settings (API keys, internal URLs, credentials) are never stored in committed config files. Use [.NET User Secrets](https://learn.microsoft.com/en-us/aspnet/core/security/app-secrets) to override settings locally.
+
+```bash
+# Set a user secret (nested keys use ":" as separator)
+dotnet user-secrets set "SectionName:Key" "value" --project MediaSet.Api/
+
+# List all configured secrets
+dotnet user-secrets list --project MediaSet.Api/
+
+# Remove a secret
+dotnet user-secrets remove "SectionName:Key" --project MediaSet.Api/
+```
+
+**Example — enabling Seq logging locally:**
+```bash
+dotnet user-secrets set "ExternalLogging:Enabled" "true" --project MediaSet.Api/
+dotnet user-secrets set "ExternalLogging:SeqUrl" "http://<your-seq-host>:5341" --project MediaSet.Api/
+```
+
+User secrets override `appsettings.json` and `appsettings.Development.json` at runtime and are stored outside the repo at `~/.microsoft/usersecrets/<id>/secrets.json`. They are never committed.
+
 ## Development Commands
 
 ```bash

--- a/MediaSet.Api/Features/Logs/Endpoints/LogsApi.cs
+++ b/MediaSet.Api/Features/Logs/Endpoints/LogsApi.cs
@@ -20,7 +20,8 @@ public static class LogsApi
             .WithName("LogClientEvent")
             .WithDescription("Accept a log event from the client and route to the configured logger")
             .Accepts<ClientLogEvent>("application/json")
-            .Produces(StatusCodes.Status202Accepted);
+            .Produces(StatusCodes.Status202Accepted)
+            .RequireRateLimiting("client-logs");
     }
 
     private static IResult HandleClientLog(
@@ -28,6 +29,11 @@ public static class LogsApi
         ILogger<Program> logger,
         IHostEnvironment environment)
     {
+        if (!Enum.TryParse<LogLevel>(logEvent.Level, ignoreCase: true, out var logLevel))
+        {
+            return Results.BadRequest($"Invalid log level: {logEvent.Level}");
+        }
+
         // Merge client properties with server-enriched metadata
         var scopeProperties = new Dictionary<string, object?>(logEvent.Properties ?? new Dictionary<string, object?>())
         {
@@ -37,11 +43,6 @@ public static class LogsApi
 
         using (logger.BeginScope(scopeProperties))
         {
-            // Parse the log level from the client
-            var logLevel = Enum.TryParse<LogLevel>(logEvent.Level, ignoreCase: true, out var level)
-                ? level
-                : LogLevel.Information;
-
             logger.Log(logLevel, "{Message}", logEvent.Message);
         }
 

--- a/MediaSet.Api/Features/Logs/Models/ClientLogEvent.cs
+++ b/MediaSet.Api/Features/Logs/Models/ClientLogEvent.cs
@@ -1,3 +1,5 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace MediaSet.Api.Features.Logs.Models;
 
 /// <summary>
@@ -5,6 +7,6 @@ namespace MediaSet.Api.Features.Logs.Models;
 /// </summary>
 public record ClientLogEvent(
     string Level,
-    string Message,
+    [MaxLength(1024)] string Message,
     DateTimeOffset Timestamp,
     Dictionary<string, object?>? Properties);

--- a/MediaSet.Api/Program.cs
+++ b/MediaSet.Api/Program.cs
@@ -30,6 +30,7 @@ using MediaSet.Api.Infrastructure.Lookup.Clients.UpcItemDb;
 using MediaSet.Api.Infrastructure.Storage;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.FileProviders;
+using System.Threading.RateLimiting;
 
 // Configure bootstrap logger for very early configuration
 LoggingExtensions.ConfigureBootstrapLogger();
@@ -275,6 +276,21 @@ else
     }
 }
 
+builder.Services.AddRateLimiter(options =>
+{
+    options.AddPolicy("client-logs", httpContext =>
+        RateLimitPartition.GetFixedWindowLimiter(
+            partitionKey: httpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown",
+            factory: _ => new FixedWindowRateLimiterOptions
+            {
+                PermitLimit = 10,
+                Window = TimeSpan.FromMinutes(1),
+                QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+                QueueLimit = 0
+            }));
+    options.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
+});
+
 // Configure SerilogTracing to capture spans and write to Seq
 using var listener = LoggingExtensions.ConfigureSerilogTracing();
 
@@ -283,6 +299,7 @@ var enableSwagger = builder.Configuration.GetValue<bool>("EnableSwagger");
 var app = builder.Build();
 
 app.UseHttpsRedirection();
+app.UseRateLimiter();
 
 // Configure logging middleware
 // Set trace ID early, before any logging occurs (must be before Swagger and other middleware)

--- a/MediaSet.Api/Shared/Extensions/LoggingExtensions.cs
+++ b/MediaSet.Api/Shared/Extensions/LoggingExtensions.cs
@@ -124,9 +124,7 @@ public static class LoggingExtensions
         {
             logging.LoggingFields =
                 HttpLoggingFields.RequestMethod |
-                HttpLoggingFields.RequestPath |
-                HttpLoggingFields.RequestBody |
-                HttpLoggingFields.ResponseBody;
+                HttpLoggingFields.RequestPath;
             logging.RequestHeaders.Add("User-Agent");
             logging.RequestHeaders.Add("traceparent");
             logging.ResponseHeaders.Add("traceparent");

--- a/MediaSet.Api/appsettings.Development.json
+++ b/MediaSet.Api/appsettings.Development.json
@@ -49,10 +49,6 @@
     "AttributionUrl": "https://musicbrainz.org/",
     "LogoPath": "/integrations/musicbrainz.svg"
   },
-  "ExternalLogging": {
-    "Enabled": true,
-    "SeqUrl": "http://192.168.50.221:5341"
-  },
   "HttpLoggingFilterOptions": {
     "ExcludedPaths": [
       "/api/logs",

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -37,6 +37,8 @@ services:
       UpcItemDbConfiguration__ApiKey: "${UPCITEMDB_API_KEY}"
       IgdbConfiguration__ClientId: "${IgdbConfiguration__ClientId}"
       IgdbConfiguration__ClientSecret: "${IgdbConfiguration__ClientSecret}"
+      ExternalLogging__Enabled: "${ExternalLogging__Enabled:-false}"
+      ExternalLogging__SeqUrl: "${ExternalLogging__SeqUrl:-}"
     volumes:
       - ./MediaSet.Api:/app
       - ./.git:/app/.git

--- a/docker-compose.podman.yml
+++ b/docker-compose.podman.yml
@@ -38,6 +38,8 @@ services:
       UpcItemDbConfiguration__ApiKey: "${UPCITEMDB_API_KEY}"
       IgdbConfiguration__ClientId: "${IgdbConfiguration__ClientId}"
       IgdbConfiguration__ClientSecret: "${IgdbConfiguration__ClientSecret}"
+      ExternalLogging__Enabled: "${ExternalLogging__Enabled:-false}"
+      ExternalLogging__SeqUrl: "${ExternalLogging__SeqUrl:-}"
     volumes:
       - ./MediaSet.Api:/app:Z
       - mediaset-api-bin:/app/bin:Z


### PR DESCRIPTION
## Summary

- Remove `RequestBody` and `ResponseBody` from global HTTP logging fields — body logging will be added explicitly at call sites where needed
- Harden `/api/logs` endpoint: validate `Level` against known `LogLevel` values (returns 400 for invalid), add `[MaxLength(1024)]` to `Message`, and apply a fixed-window rate limiter (10 req/min per IP)
- Remove hardcoded internal Seq URL and `Enabled: true` from `appsettings.Development.json` — external logging config is now managed via `.env` / docker compose env vars, keeping secrets out of committed files
- Document `VITE_SHOW_ERROR_DETAILS` and `ExternalLogging` in `.env.example` and developer docs

## Test plan

- [x] Verify API builds and tests pass
- [x] Confirm HTTP logs no longer include request/response bodies
- [x] POST to `/api/logs` with an invalid `Level` value returns 400
- [x] POST to `/api/logs` more than 10 times in a minute returns 429
- [x] Confirm Seq logging works locally when `ExternalLogging__Enabled` and `ExternalLogging__SeqUrl` are set in `.env`
- [x] Confirm error screen hides details in production (no `VITE_SHOW_ERROR_DETAILS` set) and shows them in dev

closes #575

🤖 Generated with [Claude Code](https://claude.com/claude-code)