### PR TITLE
fix(dev): reduce api container stop grace period to 2s

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -47,6 +47,7 @@ services:
       - ./.git:/app/.git:Z
       - ./data/images:/app/data/images:Z
       - nuget_cache:/nuget:Z
+    stop_grace_period: 2s
     depends_on:
       - mongodb
     networks:


### PR DESCRIPTION
## Summary

- Adds `stop_grace_period: 2s` to the api service in `docker-compose.dev.yml`
- Reduces the container stop delay from the default 10s to 2s

## Root Cause

`dotnet watch` runs as PID 1 in the dev container. In .NET 10, the runtime introduced a [breaking change](https://learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/10.0/sigterm-signal-handler) where it no longer registers a default SIGTERM handler. On Linux, PID 1 ignores signals without a registered handler, so SIGTERM from Podman goes unhandled. SIGKILL is therefore inevitable — this change just makes it arrive after 2 seconds instead of 10.

## Test plan

- [x] `./dev.sh stop` completes in ~2 seconds instead of ~10
- [x] SIGKILL warning still appears (expected — this is a .NET 10 issue, not a config error)
- [x] `./dev.sh start` / `./dev.sh restart` still work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)