### PR TITLE
fix(security): input validation and injection hardening

### DIFF
--- a/MediaSet.Api.Tests/Infrastructure/Lookup/Clients/Igdb/IgdbClientTests.cs
+++ b/MediaSet.Api.Tests/Infrastructure/Lookup/Clients/Igdb/IgdbClientTests.cs
@@ -241,6 +241,53 @@ public class IgdbClientTests
 
     #endregion
 
+    #region SanitizeTitle Tests
+
+    [Test]
+    public void SanitizeTitle_WithSemicolon_RemovesSemicolon()
+    {
+        var result = IgdbClient.SanitizeTitle("Halo; drop table games;");
+        Assert.That(result, Is.EqualTo("Halo drop table games"));
+    }
+
+    [Test]
+    public void SanitizeTitle_WithDoubleQuote_RemovesQuote()
+    {
+        var result = IgdbClient.SanitizeTitle("Game \"Edition\"");
+        Assert.That(result, Is.EqualTo("Game Edition"));
+    }
+
+    [Test]
+    public void SanitizeTitle_WithCarriageReturnAndNewline_RemovesThem()
+    {
+        var result = IgdbClient.SanitizeTitle("Game\r\nTitle");
+        Assert.That(result, Is.EqualTo("GameTitle"));
+    }
+
+    [Test]
+    public void SanitizeTitle_WithBackslash_RemovesBackslash()
+    {
+        var result = IgdbClient.SanitizeTitle("Game\\Title");
+        Assert.That(result, Is.EqualTo("GameTitle"));
+    }
+
+    [Test]
+    public void SanitizeTitle_ExceedingMaxLength_TruncatesTo200()
+    {
+        var title = new string('a', 250);
+        var result = IgdbClient.SanitizeTitle(title);
+        Assert.That(result.Length, Is.EqualTo(200));
+    }
+
+    [Test]
+    public void SanitizeTitle_WithCleanTitle_ReturnsUnchanged()
+    {
+        var result = IgdbClient.SanitizeTitle("Halo Infinite");
+        Assert.That(result, Is.EqualTo("Halo Infinite"));
+    }
+
+    #endregion
+
     #region FixCoverUrl Tests
 
     [Test]

--- a/MediaSet.Api/Infrastructure/Lookup/Clients/Igdb/IgdbClient.cs
+++ b/MediaSet.Api/Infrastructure/Lookup/Clients/Igdb/IgdbClient.cs
@@ -1,6 +1,7 @@
 using MediaSet.Api.Infrastructure.Lookup.Models;
 using Microsoft.Extensions.Options;
 using System.Text;
+using System.Text.RegularExpressions;
 
 namespace MediaSet.Api.Infrastructure.Lookup.Clients.Igdb;
 
@@ -29,7 +30,7 @@ public class IgdbClient : IIgdbClient
         {
             _logger.LogInformation("Searching IGDB for game: {Title}", title);
 
-            var escapedTitle = title.Replace("\"", "\\\"");
+            var escapedTitle = SanitizeTitle(title);
             var body = $"fields id,name,summary,first_release_date,genres.name,involved_companies.company.name,involved_companies.developer,involved_companies.publisher,platforms.name,platforms.abbreviation,age_ratings.category,age_ratings.rating,cover.url; search \"{escapedTitle}\"; limit 10;";
             var response = await SendRequestAsync("games", body, cancellationToken);
 
@@ -114,6 +115,16 @@ public class IgdbClient : IIgdbClient
         }
 
         return response;
+    }
+
+    internal static string SanitizeTitle(string title)
+    {
+        var sanitized = Regex.Replace(title, @"[;""\r\n\\]", "");
+        if (sanitized.Length > 200)
+        {
+            sanitized = sanitized[..200];
+        }
+        return sanitized;
     }
 
     internal static string? FixCoverUrl(string? url)

--- a/MediaSet.Api/Program.cs
+++ b/MediaSet.Api/Program.cs
@@ -32,6 +32,8 @@ using Microsoft.Extensions.Options;
 using Microsoft.Extensions.FileProviders;
 using System.Threading.RateLimiting;
 
+AppDomain.CurrentDomain.SetData("REGEX_DEFAULT_MATCH_TIMEOUT", TimeSpan.FromSeconds(2));
+
 // Configure bootstrap logger for very early configuration
 LoggingExtensions.ConfigureBootstrapLogger();
 var bootstrapLogger = LoggingExtensions.GetBootstrapLogger();


### PR DESCRIPTION
## Summary

- Sanitizes IGDB title input before embedding in Apicalypse query body, stripping `;`, `"`, `\r`, `\n`, and `\` and truncating to 200 chars
- Extracts sanitization as `IgdbClient.SanitizeTitle` (internal static, directly testable) with 6 new unit tests
- Sets a global 2-second regex match timeout via `AppDomain` to defend against ReDoS in `MovieLookupStrategy`
- Skipped frontend ID validation (item 1) — the API is the trust boundary; MongoDB rejects malformed ObjectIds before any query runs

## Test plan

- [x] All existing tests pass
- [x] New `SanitizeTitle` tests cover: semicolon, double quote, CR/LF, backslash, truncation, clean passthrough

closes #576