### PR TITLE
fix(security): allow unsafe-inline scripts in CSP for Remix hydration

### DIFF
--- a/MediaSet.Remix/app/root.tsx
+++ b/MediaSet.Remix/app/root.tsx
@@ -144,7 +144,7 @@ export function headers() {
   if (process.env.NODE_ENV === 'production') {
     const apiUrl = process.env.clientApiUrl || 'http://localhost:7130';
     securityHeaders['Content-Security-Policy'] =
-      `default-src 'self'; img-src 'self' data: ${apiUrl}; style-src 'self' 'unsafe-inline'; script-src 'self'`;
+      `default-src 'self'; img-src 'self' data: ${apiUrl}; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'`;
   }
 
   return securityHeaders;


### PR DESCRIPTION
## Summary

- Adds `'unsafe-inline'` to `script-src` in the production Content-Security-Policy header
- Remix injects inline scripts for client-side hydration which were blocked by the strict `script-src 'self'` directive, breaking the app in production

## Test plan

- [ ] Deploy to production and verify no CSP script-blocking errors in browser console
- [ ] Confirm Remix hydration works (interactive UI elements respond correctly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)