### PR TITLE
fix(docker): add MongoDB healthcheck and condition-based depends_on

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -12,6 +12,12 @@ services:
       MONGO_INITDB_DATABASE: "MediaSet"
     volumes:
       - ./data/mongodb:/data/db:Z
+    healthcheck:
+      test: ["CMD", "mongosh", "--eval", "db.adminCommand('ping')"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
     networks:
       - mediaset-dev
 
@@ -49,7 +55,8 @@ services:
       - nuget_cache:/nuget:Z
     stop_grace_period: 2s
     depends_on:
-      - mongodb
+      mongodb:
+        condition: service_healthy
     networks:
       - mediaset-dev
     command: ["dotnet", "watch", "run", "--urls", "http://0.0.0.0:5000"]

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -117,7 +117,8 @@ services:
       - mediaset-images:/app/data/images
 
     depends_on:
-      - mongo
+      mongo:
+        condition: service_healthy
 
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
@@ -171,6 +172,12 @@ services:
       # MONGO_INITDB_ROOT_PASSWORD: "[ReplaceThis]"
     volumes:
       - mediaset-db:/data/db
+    healthcheck:
+      test: ["CMD", "mongosh", "--eval", "db.adminCommand('ping')"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
     networks:
       - mediaset
 


### PR DESCRIPTION
## Summary

- Adds a `mongosh` ping healthcheck to the `mongo` service in both `docker-compose.prod.yml` and `docker-compose.dev.yml`
- Updates the API `depends_on` to use `condition: service_healthy` so the API only starts once MongoDB is ready

Note: Issue items 1 (latest image tags) and 2 (vsdbg version pinning) are not addressed here. Item 1 is intentional — the prod compose is an example file. Item 2 was attempted but no valid pinnable version exists for the vsdbg installer script.

## Test plan

- [x] Start dev stack with `podman-compose up` and verify API waits for MongoDB healthcheck before starting
- [x] Verify `docker inspect` shows MongoDB healthcheck running

closes #578

🤖 Generated with [Claude Code](https://claude.com/claude-code)